### PR TITLE
Implement track page

### DIFF
--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -12,7 +12,7 @@ const App = () => (
     <div>
         <Navbar />
         <ToastContainer />
-        <div className="container main">
+        <div className="container-fluid main">
             <MainContent />
         </div>
     </div>

--- a/src/components/app/MainContent.js
+++ b/src/components/app/MainContent.js
@@ -8,6 +8,7 @@ import UserPage from '../profile/UserPage';
 import Auth from '../login/Auth';
 import SearchResultsPage from '../search/SearchResultsPage';
 import SignupPage from '../signup/SignupPage';
+import TrackPage from '../track/TrackPage';
 
 const MainContent = () => (
     <Switch>
@@ -20,6 +21,7 @@ const MainContent = () => (
           path="/search/(tracks|artists|playlists|albums)/:query"
           component={SearchResultsPage}
         />
+        <Route exact path="/track/:id" component={TrackPage} />
     </Switch>
 );
 

--- a/src/components/common/SocialButton/index.js
+++ b/src/components/common/SocialButton/index.js
@@ -12,7 +12,8 @@ type Props = {
 
 const SocialButton = ({ name, url, content }: Props) => (
     <a
-      className={`btn btn-block btn-social btn-${name} text-center`}
+      className={`btn btn-block btn-social btn-${name}
+        ${content ? 'fit-content badge-pill mx-auto d-block' : ''}`}
       href={url}
     >
         {content} <span className={`fa fa-${name}`} />

--- a/src/components/common/SocialButton/index.js
+++ b/src/components/common/SocialButton/index.js
@@ -7,19 +7,21 @@ import './social-button.css';
 type Props = {
     name: string,
     url?: string,
+    content?: string,
 };
 
-const SocialButton = ({ name, url }: Props) => (
+const SocialButton = ({ name, url, content }: Props) => (
     <a
       className={`btn btn-block btn-social btn-${name} text-center`}
       href={url}
     >
-        <span className={`fa fa-${name}`} />
+        {content} <span className={`fa fa-${name}`} />
     </a>
 );
 
 SocialButton.defaultProps = {
     url: '',
+    content: '',
 };
 
 export default SocialButton;

--- a/src/components/common/SocialButton/social-button.css
+++ b/src/components/common/SocialButton/social-button.css
@@ -22,6 +22,7 @@
     font-size: 20px !important;
     color: white;
     font-weight: 300;
+    box-shadow: 0px 3px 15px rgba(0, 0, 0, 0.2);
 }
 
 .fit-content {

--- a/src/components/common/SocialButton/social-button.css
+++ b/src/components/common/SocialButton/social-button.css
@@ -24,6 +24,10 @@
     font-weight: 300;
 }
 
+.fit-content {
+    width: fit-content;
+}
+
 .fa {
     color: white;
 }

--- a/src/components/common/SocialButton/social-button.css
+++ b/src/components/common/SocialButton/social-button.css
@@ -20,6 +20,8 @@
 
 .btn-social {
     font-size: 20px !important;
+    color: white;
+    font-weight: 300;
 }
 
 .fa {

--- a/src/components/common/SongCarousel/SongCarousel.js
+++ b/src/components/common/SongCarousel/SongCarousel.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React from 'react';
+import React, { Component } from 'react';
 import Slider from 'react-slick';
 
 import 'slick-carousel/slick/slick.css';
@@ -10,27 +10,47 @@ import TrackCard from '../track/TrackCard';
 import { Track } from '../../../spotify/models';
 import './carousel.css';
 
-const sliderSettings = {
-    slidesToShow: 4,
-    slidesToScroll: 1,
-    adaptiveHeight: false,
-    lazyLoad: true,
-};
-
 type Props = {
     tracks: Array<Track>,
+    history: any,
 };
 
-const SongCarousel = ({ tracks }: Props) => {
-    const slide = (key, track) => (
-        <div key={key}><TrackCard track={track} /></div>
-    );
-    const slides = tracks.map((track, index) => slide(index, track));
-    return (
-        <Slider {...sliderSettings}>
-            {slides}
-        </Slider>
-    );
-};
+class SongCarousel extends Component<Props> {
+    constructor(props: Props) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleClick = (track: Track) => {
+        this.props.history.push(`/track/${track.id}`);
+    }
+
+    render() {
+        const { tracks } = this.props;
+
+        const slide = (key, track) => (
+            <div key={key}>
+                <TrackCard
+                  track={track}
+                  handleClick={() => this.handleClick(track)}
+                />
+            </div>
+        );
+
+        const slides = tracks.map((track, index) => slide(index, track));
+        const sliderSettings = {
+            slidesToShow: 4,
+            slidesToScroll: 1,
+            adaptiveHeight: false,
+            lazyLoad: true,
+        };
+
+        return (
+            <Slider {...sliderSettings}>
+                {slides}
+            </Slider>
+        );
+    }
+}
 
 export default SongCarousel;

--- a/src/components/common/rating/Rating.js
+++ b/src/components/common/rating/Rating.js
@@ -1,37 +1,74 @@
 /* @flow */
 
-import React from 'react';
+import React, { Component } from 'react';
 
 type Props = {
-    value: number;
+    value: number,
 };
 
-const Rating = ({ value }: Props) => {
-    const stars = [];
+type State = {
+    value: number,
+};
 
-    for (let i = 0; i < 5; i += 1) {
-        if (value >= i + 1) {
-            stars.push(<SolidStar />);
-        } else if (value >= i + 0.5) {
-            stars.push(<StarHalf />);
-        } else {
-            stars.push(<RegularStar />);
-        }
+class Rating extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = {
+            value: this.props.value,
+        };
+        this.handleClick = this.handleClick.bind(this);
     }
 
-    return <div>{ stars }</div>;
+    handleClick = (newValue: number) => {
+        console.log(newValue);
+        this.setState({ ...this.state, value: newValue });
+    };
+
+    render() {
+        const { value } = this.state;
+        const stars = [];
+
+        for (let i = 0; i < 5; i += 1) {
+            if (value >= i + 1) {
+                stars.push(<SolidStar
+                  handleClick={() => this.handleClick(i + 1)}
+                />);
+            } else if (value >= i + 0.5) {
+                stars.push(<StarHalf
+                  handleClick={() => this.handleClick(i + 1)}
+                />);
+            } else {
+                stars.push(<RegularStar
+                  handleClick={() => this.handleClick(i + 1)}
+                />);
+            }
+        }
+
+        return <div>{ stars }</div>;
+    }
+}
+
+type IconProps = {
+    handleClick: (number) => void,
 };
 
-const SolidStar = () => (
-    <i className="fas fa-star" />
+const clickableProps = (handleClick: any) => ({
+    onClick: handleClick,
+    tabIndex: 0,
+    onKeyPress: () => {},
+    role: 'button',
+});
+
+const SolidStar = ({ handleClick }: IconProps) => (
+    <i className="fas fa-star" {...clickableProps(handleClick)} />
 );
 
-const RegularStar = () => (
-    <i className="far fa-star" />
+const RegularStar = ({ handleClick }: IconProps) => (
+    <i className="far fa-star" {...clickableProps(handleClick)} />
 );
 
-const StarHalf = () => (
-    <i className="fas fa-star-half-alt" />
+const StarHalf = ({ handleClick }: IconProps) => (
+    <i className="fas fa-star-half-alt" {...clickableProps(handleClick)} />
 );
 
 export default Rating;

--- a/src/components/common/rating/Rating.js
+++ b/src/components/common/rating/Rating.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import React from 'react';
+
+type Props = {
+    value: number;
+};
+
+const Rating = ({ value }: Props) => {
+    const stars = [];
+
+    for (let i = 0; i < 5; i += 1) {
+        if (value >= i + 1) {
+            stars.push(<SolidStar />);
+        } else if (value >= i + 0.5) {
+            stars.push(<StarHalf />);
+        } else {
+            stars.push(<RegularStar />);
+        }
+    }
+
+    return <div>{ stars }</div>;
+};
+
+const SolidStar = () => (
+    <i className="fas fa-star" />
+);
+
+const RegularStar = () => (
+    <i className="far fa-star" />
+);
+
+const StarHalf = () => (
+    <i className="fas fa-star-half-alt" />
+);
+
+export default Rating;

--- a/src/components/common/track/TrackCard.js
+++ b/src/components/common/track/TrackCard.js
@@ -6,18 +6,32 @@ import { Track } from '../../../spotify/models';
 
 type Props = {
     track: Track,
+    handleClick: (track: Track) => void,
 };
 
-const TrackCard = ({ track }: Props) => (
-    <div className="card text-center">
-        <img className="card-img-top" src={track.album.imageUrl} alt="Top" />
-        <div className="card-body">
-            <h6 className="card-subtitle mb-2 text-muted text-truncate">
-                {track.name}
-            </h6>
-            <p className="card-text text-truncate">{track.stringArtists}</p>
+const TrackCard = ({ track, handleClick }: Props) => {
+    const clickableProps = {
+        onClick: handleClick,
+        tabIndex: 0,
+        onKeyPress: () => {},
+        role: 'button',
+    };
+
+    return (
+        <div className="card text-center" {...clickableProps}>
+            <img
+              className="card-img-top"
+              src={track.album.imageUrl}
+              alt="Top"
+            />
+            <div className="card-body">
+                <h6 className="card-subtitle mb-2 text-muted text-truncate">
+                    {track.name}
+                </h6>
+                <p className="card-text text-truncate">{track.stringArtists}</p>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default TrackCard;

--- a/src/components/login/Auth.js
+++ b/src/components/login/Auth.js
@@ -8,7 +8,7 @@ type Props = {
 };
 
 class Auth extends Component<Props> {
-    componentWillMount() {
+    componentDidMount() {
         localStorage.setItem('token', this.props.match.params.token);
         localStorage.setItem('refresh', this.props.match.params.refresh);
     }

--- a/src/components/profile/UserPage.js
+++ b/src/components/profile/UserPage.js
@@ -28,7 +28,7 @@ class UserPage extends Component<Props, State> {
         };
     }
 
-    componentWillMount() {
+    componentDidMount() {
         getRecentlyPlayedTracks().then((results) => {
             const recentTracks = results
                 .map(result => new Track(result.track));

--- a/src/components/profile/UserPage.js
+++ b/src/components/profile/UserPage.js
@@ -11,7 +11,7 @@ import { getRecentlyPlayedTracks, getTopPlayedTracks } from '../../spotify';
 import './UserPage.css';
 
 type Props = {
-
+    history: any,
 };
 
 type State = {
@@ -47,9 +47,15 @@ class UserPage extends Component<Props, State> {
             return (
                 <div className="text-center">
                     <h1>Recently played tracks</h1>
-                    <SongCarousel tracks={this.state.recentTracks} />
+                    <SongCarousel
+                      history={this.props.history}
+                      tracks={this.state.recentTracks}
+                    />
                     <h1>Top played tracks</h1>
-                    <SongCarousel tracks={this.state.topTracks} />
+                    <SongCarousel
+                      history={this.props.history}
+                      tracks={this.state.topTracks}
+                    />
                 </div>
             );
         }

--- a/src/components/search/results/TrackResults.js
+++ b/src/components/search/results/TrackResults.js
@@ -8,11 +8,12 @@ import { Track } from '../../../spotify/models';
 import './results.css';
 
 type Props = {
-    results: Array<any>;
+    results: Array<any>,
+    history: any,
 };
 
 type State = {
-    tracks: Array<Track>;
+    tracks: Array<Track>,
 };
 
 class TrackResult extends Component<Props, State> {
@@ -29,10 +30,17 @@ class TrackResult extends Component<Props, State> {
         });
     }
 
+    handleClick = (track: Track) => {
+        this.props.history.push(`/track/${track.id}`);
+    }
+
     render() {
         const listResults = this.state.tracks.map(track => (
             <div key={track.id} className="col-3 result">
-                <TrackCard track={track} />
+                <TrackCard
+                  track={track}
+                  handleClick={() => this.handleClick(track)}
+                />
             </div>
         ));
         return (

--- a/src/components/track/TrackPage.css
+++ b/src/components/track/TrackPage.css
@@ -7,11 +7,39 @@
 .background {
     height: 100%;
     width: 100%;
-    filter: grayscale(30%);
     background-size: 100%;
-    opacity: 0.3;
     background-position-y: 30%;
-    filter: blur(3px);
+    opacity: 0.9;
+}
+
+.background::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0.9;
+    /* Gradient made with https://larsenwork.com/easing-gradients/ */
+    background: linear-gradient(
+        to bottom,
+        hsla(0, 0%, 100%, 0.15) 0%,
+        hsla(0, 0%, 98.73%, 0.161) 7.7%,
+        hsla(0, 0%, 95.14%, 0.191) 14%,
+        hsla(0, 0%, 89.6%, 0.238) 19.3%,
+        hsla(0, 0%, 82.46%, 0.299) 23.9%,
+        hsla(0, 0%, 74.07%, 0.37) 27.9%,
+        hsla(0, 0%, 64.8%, 0.449) 31.7%,
+        hsla(0, 0%, 54.99%, 0.533) 35.6%,
+        hsla(0, 0%, 45.01%, 0.617) 39.8%,
+        hsla(0, 0%, 35.2%, 0.701) 44.5%,
+        hsla(0, 0%, 25.93%, 0.78) 50.1%,
+        hsla(0, 0%, 17.54%, 0.851) 56.8%,
+        hsla(0, 0%, 10.4%, 0.912) 64.8%,
+        hsla(0, 0%, 4.86%, 0.959) 74.5%,
+        hsla(0, 0%, 1.27%, 0.989) 86.2%,
+        hsl(0, 0%, 0%) 100%
+    );
 }
 
 .content {
@@ -26,6 +54,7 @@
     display: block;
     margin: 0 auto;
     width: 30vh;
+    box-shadow: 0px 3px 15px rgba(0, 0, 0, 0.2);
 }
 
 .padding {

--- a/src/components/track/TrackPage.css
+++ b/src/components/track/TrackPage.css
@@ -1,6 +1,6 @@
 .header {
     position: relative;
-    height: 50vh;
+    height: 70vh;
     width: 100%;
 }
 
@@ -26,4 +26,13 @@
     display: block;
     margin: 0 auto;
     width: 30vh;
+}
+
+.padding {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.rating-title {
+    font-weight: 300;
 }

--- a/src/components/track/TrackPage.css
+++ b/src/components/track/TrackPage.css
@@ -1,0 +1,29 @@
+.header {
+    position: relative;
+    height: 50vh;
+    width: 100%;
+}
+
+.background {
+    height: 100%;
+    width: 100%;
+    filter: grayscale(30%);
+    background-size: 100%;
+    opacity: 0.3;
+    background-position-y: 30%;
+    filter: blur(3px);
+}
+
+.content {
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.center-image {
+    display: block;
+    margin: 0 auto;
+    width: 30vh;
+}

--- a/src/components/track/TrackPage.js
+++ b/src/components/track/TrackPage.js
@@ -2,8 +2,11 @@
 
 import React, { Component } from 'react';
 
-import { Track } from '../../spotify/models';
-import { getTrackInfo } from '../../spotify';
+import { Track, AudioFeatures } from '../../spotify/models';
+import { getTrackInfo, getAudioFeatures } from '../../spotify';
+
+import Header from './TrackPageHeader';
+import Body from './TrackPageBody';
 
 import './TrackPage.css';
 
@@ -12,6 +15,7 @@ type Props = {
 };
 
 type State = {
+    audioFeatures: AudioFeatures,
     trackId: string,
     track: Track,
 };
@@ -22,6 +26,7 @@ class TrackPage extends Component<Props, State> {
         this.state = {
             trackId: this.props.match.params.id,
             track: new Track(),
+            audioFeatures: new AudioFeatures(),
         };
     }
 
@@ -29,70 +34,31 @@ class TrackPage extends Component<Props, State> {
         getTrackInfo(this.state.trackId).then(trackJson => (
             this.setState({ ...this.state, track: new Track(trackJson) })
         ));
+
+        getAudioFeatures(this.state.trackId).then(audioFeaturesJson => (
+            this.setState({
+                ...this.state,
+                audioFeatures: new AudioFeatures(audioFeaturesJson),
+            })
+        ));
     }
 
     render() {
-        const { track } = this.state;
+        const { track, audioFeatures } = this.state;
 
         if (!track.name) return <div />;
 
         return (
-            <Header track={track} />
+            <div>
+                <Header track={track} />
+                <Body
+                  audioFeatures={audioFeatures}
+                  userRating={4.5}
+                  averageRating={3.7}
+                />
+            </div>
         );
     }
 }
-
-type HeaderProps = {
-    track: Track,
-};
-
-const Header = ({ track }: HeaderProps) => (
-    <div className="header">
-        <HeaderBackground imageUrl={track.album.imageUrl} />
-        <HeaderContent track={track} />
-    </div>
-);
-
-type HeaderBackgroundProps = {
-    imageUrl: string,
-};
-
-const HeaderBackground = ({ imageUrl }: HeaderBackgroundProps) => {
-    const style = {
-        backgroundImage: `url(${imageUrl})`,
-    };
-
-    return (<div className="background" style={style} />);
-};
-
-const HeaderContent = ({ track }: HeaderProps) => (
-    <div className="content">
-        <img alt="Album" className="center-image" src={track.album.imageUrl} />
-        <br />
-        <TrackInfo track={track} />
-    </div>
-);
-
-const getFormattedDuration = (durationInMillis: number) => {
-    const minutes = Math.floor(durationInMillis / 60000);
-    const seconds = Math.floor((durationInMillis % 60000) / 1000);
-
-    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
-};
-
-const TrackInfo = ({ track }: HeaderProps) => {
-    const releaseYear = track.album.releaseDate.substring(0, 4);
-    const duration = getFormattedDuration(track.durationInMillis);
-
-    return (
-        <div className="text-center">
-            <h2>{ track.name }</h2>
-            <h4>by { track.stringArtists }</h4>
-            <p>
-                { track.album.name } &bull; { releaseYear } &bull; { duration }
-            </p>
-        </div>
-    );
-};
 
 export default TrackPage;

--- a/src/components/track/TrackPage.js
+++ b/src/components/track/TrackPage.js
@@ -5,8 +5,8 @@ import React, { Component } from 'react';
 import { Track, AudioFeatures } from '../../spotify/models';
 import { getTrackInfo, getAudioFeatures } from '../../spotify';
 
-import Header from './TrackPageHeader';
-import Body from './TrackPageBody';
+import TrackPageHeader from './TrackPageHeader';
+import TrackPageBody from './TrackPageBody';
 
 import './TrackPage.css';
 
@@ -30,7 +30,7 @@ class TrackPage extends Component<Props, State> {
         };
     }
 
-    componentWillMount() {
+    componentDidMount() {
         getTrackInfo(this.state.trackId).then(trackJson => (
             this.setState({ ...this.state, track: new Track(trackJson) })
         ));
@@ -50,8 +50,8 @@ class TrackPage extends Component<Props, State> {
 
         return (
             <div>
-                <Header track={track} />
-                <Body
+                <TrackPageHeader track={track} />
+                <TrackPageBody
                   audioFeatures={audioFeatures}
                   userRating={4.5}
                   averageRating={3.7}

--- a/src/components/track/TrackPage.js
+++ b/src/components/track/TrackPage.js
@@ -1,0 +1,98 @@
+/* @flow */
+
+import React, { Component } from 'react';
+
+import { Track } from '../../spotify/models';
+import { getTrackInfo } from '../../spotify';
+
+import './TrackPage.css';
+
+type Props = {
+    match: any,
+};
+
+type State = {
+    trackId: string,
+    track: Track,
+};
+
+class TrackPage extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = {
+            trackId: this.props.match.params.id,
+            track: new Track(),
+        };
+    }
+
+    componentWillMount() {
+        getTrackInfo(this.state.trackId).then(trackJson => (
+            this.setState({ ...this.state, track: new Track(trackJson) })
+        ));
+    }
+
+    render() {
+        const { track } = this.state;
+
+        if (!track.name) return <div />;
+
+        return (
+            <Header track={track} />
+        );
+    }
+}
+
+type HeaderProps = {
+    track: Track,
+};
+
+const Header = ({ track }: HeaderProps) => (
+    <div className="header">
+        <HeaderBackground imageUrl={track.album.imageUrl} />
+        <HeaderContent track={track} />
+    </div>
+);
+
+type HeaderBackgroundProps = {
+    imageUrl: string,
+};
+
+const HeaderBackground = ({ imageUrl }: HeaderBackgroundProps) => {
+    const style = {
+        backgroundImage: `url(${imageUrl})`,
+    };
+
+    return (<div className="background" style={style} />);
+};
+
+const HeaderContent = ({ track }: HeaderProps) => (
+    <div className="content">
+        <img alt="Album" className="center-image" src={track.album.imageUrl} />
+        <br />
+        <TrackInfo track={track} />
+    </div>
+);
+
+const getFormattedDuration = (durationInMillis: number) => {
+    const minutes = Math.floor(durationInMillis / 60000);
+    const seconds = Math.floor((durationInMillis % 60000) / 1000);
+
+    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+};
+
+const TrackInfo = ({ track }: HeaderProps) => {
+    const releaseYear = track.album.releaseDate.substring(0, 4);
+    const duration = getFormattedDuration(track.durationInMillis);
+
+    return (
+        <div className="text-center">
+            <h2>{ track.name }</h2>
+            <h4>by { track.stringArtists }</h4>
+            <p>
+                { track.album.name } &bull; { releaseYear } &bull; { duration }
+            </p>
+        </div>
+    );
+};
+
+export default TrackPage;

--- a/src/components/track/TrackPageBody.js
+++ b/src/components/track/TrackPageBody.js
@@ -1,0 +1,85 @@
+/* @flow */
+
+import React from 'react';
+
+import { AudioFeatures } from '../../spotify/models';
+import Rating from '../common/rating/Rating';
+
+type Props = {
+    audioFeatures: AudioFeatures,
+    userRating: number,
+    averageRating: number,
+};
+
+const Body = ({ audioFeatures, userRating, averageRating }: Props) => (
+    <div className="container">
+        <AudioFeatureTagList audioFeatures={audioFeatures} />
+        <TrackRating userRating={userRating} averageRating={averageRating} />
+    </div>
+);
+
+type AudioFeatureTagListProps = {
+    audioFeatures: AudioFeatures,
+};
+
+const AudioFeatureTagList = ({ audioFeatures }: AudioFeatureTagListProps) => {
+    const { tags } = audioFeatures;
+    const tagColumns = tags.map((tag) => {
+        if (!tag.value) return <div />;
+        return <AudioFeatureTag feature={tag.feature} value={tag.value} />;
+    });
+
+    return (
+        <div className="border padding">
+            <div className="row justify-content-md-center text-center">
+                {tagColumns}
+            </div>
+        </div>
+    );
+};
+
+type AudioFeatureTagProps = {
+    feature: string,
+    value: string,
+};
+
+const AudioFeatureTag = ({ feature, value }: AudioFeatureTagProps) => (
+    <div className="col-md-auto">
+        <div className="btn-group" role="group">
+            <button className="btn btn-dark btn-sm">
+                {feature}
+            </button>
+            <button className="btn btn-secondary btn-sm">
+                {value}
+            </button>
+        </div>
+    </div>
+);
+
+type TrackRatingProps = {
+    userRating: number,
+    averageRating: number,
+};
+
+const TrackRating = ({ userRating, averageRating }: TrackRatingProps) => (
+    <div className="padding row justify-content-md-center text-center">
+        <TrackRatingColumn rating={userRating} title="YOUR RATING" />
+        <TrackRatingColumn rating={averageRating} title="AVERAGE RATING" />
+    </div>
+);
+
+type TrackRatingColumnProps = {
+    rating: number,
+    title: string,
+};
+
+const TrackRatingColumn = ({ rating, title }: TrackRatingColumnProps) => (
+    <div className="col-md-auto border padding">
+        <h5 className="rating-title">{title}</h5>
+        <h5>
+            <Rating value={rating} />
+        </h5>
+    </div>
+);
+
+export default Body;

--- a/src/components/track/TrackPageBody.js
+++ b/src/components/track/TrackPageBody.js
@@ -11,7 +11,7 @@ type Props = {
     averageRating: number,
 };
 
-const Body = ({ audioFeatures, userRating, averageRating }: Props) => (
+const TrackPageBody = ({ audioFeatures, userRating, averageRating }: Props) => (
     <div className="container">
         <AudioFeatureTagList audioFeatures={audioFeatures} />
         <TrackRating userRating={userRating} averageRating={averageRating} />
@@ -82,4 +82,4 @@ const TrackRatingColumn = ({ rating, title }: TrackRatingColumnProps) => (
     </div>
 );
 
-export default Body;
+export default TrackPageBody;

--- a/src/components/track/TrackPageHeader.js
+++ b/src/components/track/TrackPageHeader.js
@@ -9,7 +9,7 @@ type Props = {
     track: Track,
 };
 
-const Header = ({ track }: Props) => (
+const TrackPageHeader = ({ track }: Props) => (
     <div className="header">
         <HeaderBackground imageUrl={track.album.imageUrl} />
         <HeaderContent track={track} />
@@ -54,4 +54,4 @@ const SpotifyButton = ({ trackUrl }: SpotifyButtonProps) => (
     <SocialButton name="spotify" url={trackUrl} content="PLAY TRACK" />
 );
 
-export default Header;
+export default TrackPageHeader;

--- a/src/components/track/TrackPageHeader.js
+++ b/src/components/track/TrackPageHeader.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+import React from 'react';
+
+import { Track } from '../../spotify/models';
+import SocialButton from '../common/SocialButton';
+
+type Props = {
+    track: Track,
+};
+
+const Header = ({ track }: Props) => (
+    <div className="header">
+        <HeaderBackground imageUrl={track.album.imageUrl} />
+        <HeaderContent track={track} />
+    </div>
+);
+
+type BackgroundProps = {
+    imageUrl: string,
+};
+
+const HeaderBackground = ({ imageUrl }: BackgroundProps) => {
+    const style = {
+        backgroundImage: `url(${imageUrl})`,
+    };
+
+    return (<div className="background" style={style} />);
+};
+
+const HeaderContent = ({ track }: Props) => (
+    <div className="content">
+        <img alt="Album" className="center-image" src={track.album.imageUrl} />
+        <TrackInfo track={track} />
+    </div>
+);
+
+const TrackInfo = ({ track }: Props) => (
+    <div className="text-center">
+        <h1>{ track.name }</h1>
+        <h4>by { track.stringArtists }</h4>
+        <p>
+            {track.albumTitle} &bull; {track.releaseYear} &bull; {track.length}
+        </p>
+        <SpotifyButton trackUrl={track.spotifyUrl} />
+    </div>
+);
+
+type SpotifyButtonProps = {
+    trackUrl: string,
+};
+
+const SpotifyButton = ({ trackUrl }: SpotifyButtonProps) => (
+    <SocialButton name="spotify" url={trackUrl} content="PLAY IT ON SPOTIFY" />
+);
+
+export default Header;

--- a/src/components/track/TrackPageHeader.js
+++ b/src/components/track/TrackPageHeader.js
@@ -36,7 +36,7 @@ const HeaderContent = ({ track }: Props) => (
 );
 
 const TrackInfo = ({ track }: Props) => (
-    <div className="text-center">
+    <div className="text-center text-light">
         <h1>{ track.name }</h1>
         <h4>by { track.stringArtists }</h4>
         <p>
@@ -51,7 +51,7 @@ type SpotifyButtonProps = {
 };
 
 const SpotifyButton = ({ trackUrl }: SpotifyButtonProps) => (
-    <SocialButton name="spotify" url={trackUrl} content="PLAY IT ON SPOTIFY" />
+    <SocialButton name="spotify" url={trackUrl} content="PLAY TRACK" />
 );
 
 export default Header;

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <title>Musicritic</title>
     <!--- ROBOTO FONT -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
 </head>
 <body>
     <div id='root'></div> 

--- a/src/spotify/index.js
+++ b/src/spotify/index.js
@@ -34,3 +34,9 @@ export const search = async (query: string) => {
         .get('/search', params);
     return response.data;
 };
+
+export const getTrackInfo = async (id: string) => {
+    const response = await getAxiosInstance()
+        .get(`/tracks/${id}`);
+    return response.data;
+};

--- a/src/spotify/index.js
+++ b/src/spotify/index.js
@@ -40,3 +40,9 @@ export const getTrackInfo = async (id: string) => {
         .get(`/tracks/${id}`);
     return response.data;
 };
+
+export const getAudioFeatures = async (id: string) => {
+    const response = await getAxiosInstance()
+        .get(`/audio-features/${id}`);
+    return response.data;
+};

--- a/src/spotify/models/index.js
+++ b/src/spotify/models/index.js
@@ -43,13 +43,17 @@ export class Track {
     id: string;
     imageUrl: string;
     name: string;
+    explicit: boolean;
 
     constructor(trackJson: any) {
-        this.album = new Album(trackJson.album);
-        this.artists = trackJson.artists.map(artist => new Artist(artist));
-        this.durationInMillis = trackJson.duration_ms;
-        this.id = trackJson.id;
-        this.name = trackJson.name;
+        if (trackJson) {
+            this.album = new Album(trackJson.album);
+            this.artists = trackJson.artists.map(artist => new Artist(artist));
+            this.durationInMillis = trackJson.duration_ms;
+            this.id = trackJson.id;
+            this.name = trackJson.name;
+            this.explicit = trackJson.explicit;
+        }
     }
 
     get stringArtists() {

--- a/src/spotify/models/index.js
+++ b/src/spotify/models/index.js
@@ -44,6 +44,8 @@ export class Track {
     imageUrl: string;
     name: string;
     explicit: boolean;
+    popularity: number;
+    spotifyUrl: string;
 
     constructor(trackJson: any) {
         if (trackJson) {
@@ -53,12 +55,25 @@ export class Track {
             this.id = trackJson.id;
             this.name = trackJson.name;
             this.explicit = trackJson.explicit;
+            this.popularity = trackJson.popularity;
+            this.spotifyUrl = trackJson.external_urls.spotify;
         }
     }
 
     get stringArtists() {
         const artistNames = this.artists.map(artist => artist.name);
         return artistNames.join(', ');
+    }
+
+    get popularityRank() {
+        if (this.popularity >= 90) {
+            return 'HIGHLY POPULAR';
+        } else if (this.popularity >= 75) {
+            return 'POPULAR';
+        } else if (this.popularity >= 50) {
+            return 'SOMEWHAT POPULAR';
+        }
+        return '';
     }
 }
 
@@ -73,5 +88,99 @@ export class Playlist {
         this.imageUrl = playlistJson.images[0].url;
         this.name = playlistJson.name;
         this.owner = playlistJson.owner.display_name || playlistJson.owner.id;
+    }
+}
+
+export class AudioFeatures {
+    danceability: number;
+    energy: number;
+    key: number;
+    loudness: number;
+    mode: number;
+    speechiness: number;
+    acousticness: number;
+    instrumentalness: number;
+    liveness: number;
+    valence: number;
+    tempo: number;
+
+    constructor(audioFeaturesJson: any) {
+        if (audioFeaturesJson) {
+            this.danceability = audioFeaturesJson.danceability;
+            this.energy = audioFeaturesJson.energy;
+            this.key = audioFeaturesJson.key;
+            this.loudness = audioFeaturesJson.loudness;
+            this.mode = audioFeaturesJson.mode;
+            this.speechiness = audioFeaturesJson.speechiness;
+            this.acousticness = audioFeaturesJson.acousticness;
+            this.instrumentalness = audioFeaturesJson.instrumentalness;
+            this.liveness = audioFeaturesJson.liveness;
+            this.valence = audioFeaturesJson.valence;
+            this.tempo = audioFeaturesJson.tempo;
+        }
+    }
+
+    static rankFeatureLikelihood(feature: number) {
+        if (feature > 0.9) {
+            return 'MOST CERTAINLY';
+        } else if (feature > 0.8) {
+            return 'VERY LIKELY';
+        } else if (feature > 0.7) {
+            return 'LIKELY';
+        }
+        return '';
+    }
+
+    static rankFeature(feature: number) {
+        if (feature > 0.85) {
+            return 'VERY HIGH';
+        } else if (feature > 0.75) {
+            return 'HIGH';
+        } else if (feature > 0.5) {
+            return 'MEDIUM HIGH';
+        } else if (feature > 0.25) {
+            return 'MEDIUM LOW';
+        } else if (feature > 0.15) {
+            return 'LOW';
+        }
+        return 'VERY LOW';
+    }
+
+    get tags() {
+        const tags = [];
+
+        tags.push(
+            {
+                feature: 'TEMPO',
+                value: `${Math.round(this.tempo)} BPM`,
+            },
+            {
+                feature: 'ACOUSTIC',
+                value: AudioFeatures.rankFeatureLikelihood(this.acousticness),
+            },
+            {
+                feature: 'DANCEABILITY',
+                value: AudioFeatures.rankFeature(this.danceability),
+            },
+            {
+                feature: 'ENERGY',
+                value: AudioFeatures.rankFeature(this.danceability),
+            },
+            {
+                feature: 'INSTRUMENTAL',
+                value: AudioFeatures
+                    .rankFeatureLikelihood(this.instrumentalness),
+            },
+            {
+                feature: 'LIVE',
+                value: AudioFeatures.rankFeatureLikelihood(this.liveness),
+            },
+            {
+                feature: 'POSITIVENESS',
+                value: AudioFeatures.rankFeature(this.valence),
+            },
+        );
+
+        return tags;
     }
 }

--- a/src/spotify/models/index.js
+++ b/src/spotify/models/index.js
@@ -75,6 +75,21 @@ export class Track {
         }
         return '';
     }
+
+    get releaseYear() {
+        return this.album.releaseDate.substring(0, 4);
+    }
+
+    get length() {
+        const minutes = Math.floor(this.durationInMillis / 60000);
+        const seconds = Math.floor((this.durationInMillis % 60000) / 1000);
+
+        return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+    }
+
+    get albumTitle() {
+        return this.album.name;
+    }
 }
 
 export class Playlist {


### PR DESCRIPTION
The current PR includes the following modifications/implementations:
- Update Spotify models to keep more attributes related to tracks;
- Add functions to request further information and audio features of a track by its id;
- Create a Audio Feature model to encapsulate such logic;
- Add properties to allow Track Cards to redirect to their respective Track Pages when clicked on;
- Create basic display of a Rating component.

**Track page example (route: /track/id):**
![image](https://user-images.githubusercontent.com/20714148/43984210-82c5c3e2-9cd5-11e8-9b57-e4ac9b210ac8.png)
> Observation: I plan this page to be as wide as the whole screen (but it's inside a container) and not to exist a margin between it and the Navbar.

Most of the other pages didn't undergo major changes. I have changed the className of the div that wraps the MainContent component from _container_ to _container-fluid_, but this alteration was made just to allow us visualize the main page's width a little better.
![image](https://user-images.githubusercontent.com/20714148/43984374-8e5b813c-9cd6-11e8-8d03-3bac201a885c.png)
> The pages that use the SocialButton component (LoginPage, UserPage and SignupPage, as far as I'm concerned) have changed just a little bit with the addition of a shadow to this component.