### PR TITLE
Create display for the currently playing track

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -15,7 +15,10 @@ if (process.env.NODE_ENV === 'production') {
 const config = {};
 
 config.spotify = {
-    scope: 'user-read-email user-read-recently-played user-top-read',
+    scope: `user-read-email
+            user-read-currently-playing
+            user-read-recently-played
+            user-top-read`,
     authBaseUri: 'https://accounts.spotify.com',
     clientId: process.env.SPOTIFY_CLIENT_ID,
     clientSecret: process.env.SPOTIFY_CLIENT_SECRET,

--- a/src/api/SpotifyWebAPI.js
+++ b/src/api/SpotifyWebAPI.js
@@ -23,3 +23,6 @@ export const getTrack = async (id: string) => spotify.getTrack(id);
 
 export const getAudioFeaturesForTrack = async (id: string) =>
     spotify.getAudioFeaturesForTrack(id);
+
+export const getCurrentUserCurrentlyPlayingTrack = async () =>
+    spotify.getCurrentUserCurrentlyPlayingTrack();

--- a/src/components/common/track/RecentTracksCarousel.js
+++ b/src/components/common/track/RecentTracksCarousel.js
@@ -38,9 +38,10 @@ class RecentTracksCarousel extends Component<Props> {
         const slides = tracks.map((track, index) => slide(index, track));
         const sliderSettings = {
             slidesToShow: 4,
-            slidesToScroll: 1,
+            slidesToScroll: 4,
             adaptiveHeight: false,
             lazyLoad: true,
+            speed: 2000,
         };
 
         return <Slider {...sliderSettings}>{slides}</Slider>;

--- a/src/components/common/track/TrackCarousel.js
+++ b/src/components/common/track/TrackCarousel.js
@@ -41,9 +41,10 @@ class TrackCarousel extends Component<Props> {
         const slides = tracks.map((track, index) => slide(index, track));
         const sliderSettings = {
             slidesToShow: 4,
-            slidesToScroll: 1,
+            slidesToScroll: 4,
             adaptiveHeight: false,
             lazyLoad: true,
+            speed: 2000,
         };
 
         return <Slider {...sliderSettings}>{slides}</Slider>;

--- a/src/components/profile/CurrentlyPlayingTrack.js
+++ b/src/components/profile/CurrentlyPlayingTrack.js
@@ -1,0 +1,65 @@
+/* @flow */
+
+import React from 'react';
+import { CurrentlyPlaying, Track } from 'spotify-web-sdk';
+
+type Props = {
+    currentlyPlaying: CurrentlyPlaying,
+    history: any,
+};
+
+const CurrentlyPlayingTrack = ({ currentlyPlaying, history }: Props) => {
+    if (currentlyPlaying.isPlaying) {
+        const clickableProps = {
+            onClick: () => history.push(`/track/${currentlyPlaying.item.id}`),
+            tabIndex: 0,
+            onKeyPress: () => {},
+            role: 'button',
+        };
+
+        return (
+            <div className="border row" {...clickableProps}>
+                <CurrentlyPlayingTrackImage
+                  imageUrl={currentlyPlaying.item.album.imageUrl}
+                />
+                <CurrentlyPlayingTrackInfo
+                  track={currentlyPlaying.item}
+                />
+            </div>
+        );
+    }
+
+    return <div />;
+};
+
+type ImageProps = {
+    imageUrl: string,
+};
+
+const CurrentlyPlayingTrackImage = ({ imageUrl }: ImageProps) => (
+    <div className="current-track-img text-center col-xl-3 col-lg-4 col-md-5">
+        <img className="current-track" src={imageUrl} alt="Top" />
+    </div>
+);
+
+type InfoProps = {
+    track: Track,
+};
+
+const CurrentlyPlayingTrackInfo = ({ track }: InfoProps) => (
+    <div className="align-self-center col-xl-9 col-lg-8 col-md-7">
+        <article className="current-track-info text-center">
+            <h3 className="text-truncate">
+                {track.stringArtists}
+            </h3>
+            <h1 className="display-4 text-truncate">
+                {track.name}
+            </h1>
+            <h4 className="text-muted text-truncate">
+                From the album <i>{track.album.name}</i>
+            </h4>
+        </article>
+    </div>
+);
+
+export default CurrentlyPlayingTrack;

--- a/src/components/profile/UserPage.css
+++ b/src/components/profile/UserPage.css
@@ -1,4 +1,11 @@
-h1 {
-    margin-bottom: 10px;
-    margin-top: 10px;
+.current-track {
+    height: 30vh;
+}
+
+.current-track-img {
+    padding: 1vh;
+}
+
+.current-track-info {
+    padding: 10px;
 }

--- a/src/components/profile/UserPage.js
+++ b/src/components/profile/UserPage.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { Track, PlayHistory } from 'spotify-web-sdk';
+import { Track, PlayHistory, CurrentlyPlaying } from 'spotify-web-sdk';
 
 import TrackCarousel from '../common/track/TrackCarousel';
 import SocialButton from './../common/social-button/SocialButton';
@@ -9,16 +9,19 @@ import SocialButton from './../common/social-button/SocialButton';
 import {
     getRecentlyPlayedTracks,
     getTopPlayedTracks,
+    getCurrentUserCurrentlyPlayingTrack,
 } from '../../api/SpotifyWebAPI';
 
 import './UserPage.css';
 import RecentTracksCarousel from '../common/track/RecentTracksCarousel';
+import CurrentlyPlayingTrack from './CurrentlyPlayingTrack';
 
 type Props = {
     history: any,
 };
 
 type State = {
+    currentlyPlaying: CurrentlyPlaying,
     recentTracks: PlayHistory[],
     topTracks: Track[],
 };
@@ -27,12 +30,16 @@ class UserPage extends Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
+            currentlyPlaying: {},
             recentTracks: [],
             topTracks: [],
         };
     }
 
     componentDidMount() {
+        getCurrentUserCurrentlyPlayingTrack().then(currentlyPlaying =>
+            this.setState({ currentlyPlaying }));
+
         getRecentlyPlayedTracks().then(recentTracks =>
             this.setState({ recentTracks }));
 
@@ -40,18 +47,26 @@ class UserPage extends Component<Props, State> {
     }
 
     render() {
+        const { history } = this.props;
+        const { currentlyPlaying, recentTracks, topTracks } = this.state;
+
         if (localStorage.getItem('token')) {
             return (
-                <div className="">
-                    <h1>Your recently played tracks</h1>
-                    <RecentTracksCarousel
-                      history={this.props.history}
-                      tracks={this.state.recentTracks}
+                <div>
+                    <h1 className="display-3">You are listening to</h1>
+                    <CurrentlyPlayingTrack
+                      history={history}
+                      currentlyPlaying={currentlyPlaying}
                     />
-                    <h1>Your top played tracks</h1>
+                    <h1 className="display-3">Your recently played tracks</h1>
+                    <RecentTracksCarousel
+                      history={history}
+                      tracks={recentTracks}
+                    />
+                    <h1 className="display-3">Your top played tracks</h1>
                     <TrackCarousel
-                      history={this.props.history}
-                      tracks={this.state.topTracks}
+                      history={history}
+                      tracks={topTracks}
                     />
                 </div>
             );


### PR DESCRIPTION
The UserPage component now displays the track being currently played by the user (if any). Minor updates include the carousels, which now scroll 4 slides at a time, and a newly added scope to the Spotify configurations.