### PR TITLE
Add props to AlbumCard to redirect to album page when clicked

### DIFF
--- a/src/components/common/album/AlbumCard.js
+++ b/src/components/common/album/AlbumCard.js
@@ -5,18 +5,27 @@ import { AlbumSimplified } from 'spotify-web-sdk';
 
 type Props = {
     album: AlbumSimplified,
+    handleClick: (album: AlbumSimplified) => void,
 };
 
-const AlbumCard = ({ album }: Props) => (
-    <div className="card text-center">
-        <img className="card-img-top" src={album.imageUrl} alt="Card top" />
-        <div className="card-body">
-            <h6 className="card-subtitle mb-2 text-muted text-truncate">
-                {album.name}
-            </h6>
-            <p className="card-text">{album.stringArtists}</p>
+const AlbumCard = ({ album, handleClick }: Props) => {
+    const clickableProps = {
+        onClick: handleClick,
+        tabIndex: 0,
+        onKeyPress: () => {},
+        role: 'button',
+    };
+    return (
+        <div className="card text-center" {...clickableProps}>
+            <img className="card-img-top" src={album.imageUrl} alt="Card top" />
+            <div className="card-body">
+                <h6 className="card-subtitle mb-2 text-muted text-truncate">
+                    {album.name}
+                </h6>
+                <p className="card-text">{album.stringArtists}</p>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export default AlbumCard;

--- a/src/components/search/results/AlbumResults.js
+++ b/src/components/search/results/AlbumResults.js
@@ -8,11 +8,12 @@ import AlbumCard from '../../common/album/AlbumCard';
 import './Results.css';
 
 type Props = {
-    results: Array<AlbumSimplified>,
+    history: any,
+    results: AlbumSimplified[],
 };
 
 type State = {
-    albums: Array<AlbumSimplified>,
+    albums: AlbumSimplified[],
 };
 
 class AlbumResult extends Component<Props, State> {
@@ -29,10 +30,17 @@ class AlbumResult extends Component<Props, State> {
         });
     }
 
+    handleClick = (album: AlbumSimplified) => {
+        this.props.history.push(`/album/${album.id}/`);
+    }
+
     render() {
         const listResults = this.state.albums.map(album => (
             <div key={album.id} className="col-3 result">
-                <AlbumCard album={album} />
+                <AlbumCard
+                  album={album}
+                  handleClick={() => this.handleClick(album)}
+                />
             </div>
         ));
         return <div className="row">{listResults}</div>;


### PR DESCRIPTION
The AlbumCard component received new props, allowing it to handle click events, similarly to the TrackCard. Through the AlbumResults component, the handleClick prop passed to each AlbumCard is a function that redirects to the matching album page.