### PR TITLE
Make the SongCarousel mobile friendly

### DIFF
--- a/src/components/profile/RecentTracksCarousel.js
+++ b/src/components/profile/RecentTracksCarousel.js
@@ -47,6 +47,22 @@ class RecentTracksCarousel extends Component<Props> {
             adaptiveHeight: false,
             lazyLoad: true,
             speed: 2000,
+            responsive: [
+                {
+                    breakpoint: 1024,
+                    settings: {
+                        slidesToShow: 3,
+                        slidesToScroll: 3,
+                    },
+                },
+                {
+                    breakpoint: 600,
+                    settings: {
+                        slidesToShow: 1,
+                        slidesToScroll: 1,
+                    },
+                },
+            ],
         };
 
         return (

--- a/src/components/profile/TopTracksCarousel.js
+++ b/src/components/profile/TopTracksCarousel.js
@@ -46,6 +46,22 @@ class TrackCarousel extends Component<Props> {
             adaptiveHeight: false,
             lazyLoad: true,
             speed: 2000,
+            responsive: [
+                {
+                    breakpoint: 1024,
+                    settings: {
+                        slidesToShow: 3,
+                        slidesToScroll: 3,
+                    },
+                },
+                {
+                    breakpoint: 600,
+                    settings: {
+                        slidesToShow: 1,
+                        slidesToScroll: 1,
+                    },
+                },
+            ],
         };
 
         return (


### PR DESCRIPTION
Resolves #5 

I used this [props](https://react-slick.neostack.com/docs/api#responsive) to make the carousel responsive at some breakpoints.

**Screenshots**:

<img width="1680" alt="Screen Shot 2019-04-20 at 00 45 39" src="https://user-images.githubusercontent.com/6867958/56452155-d6213e80-6305-11e9-9467-7272c298c1f1.png">
<img width="568" alt="Screen Shot 2019-04-20 at 00 45 52" src="https://user-images.githubusercontent.com/6867958/56452156-d6213e80-6305-11e9-8de5-4a75cc26abff.png">
<img width="1680" alt="Screen Shot 2019-04-20 at 00 46 02" src="https://user-images.githubusercontent.com/6867958/56452157-d6213e80-6305-11e9-99dc-4f64ffd56b4c.png">
