### PR TITLE
Makes CurrentlyPlayingTrack updates itself with an interval

### DIFF
--- a/src/components/profile/CurrentlyPlayingTrackSection.js
+++ b/src/components/profile/CurrentlyPlayingTrackSection.js
@@ -1,31 +1,49 @@
 /* @flow */
 
-import React from 'react';
-import { CurrentlyPlaying } from 'spotify-web-sdk';
-
+import React, { useState, useEffect, Fragment } from 'react';
+import { getCurrentUserCurrentlyPlayingTrack } from '../../api/SpotifyWebAPI';
+import useInterval from '../../utils/hooks';
 import CurrentlyPlayingTrack from './CurrentlyPlayingTrack';
 
 type CurrentlyPlayingTrackSectionProps = {
-    currentlyPlaying: CurrentlyPlaying,
     history: any,
 };
 
 const CurrentlyPlayingTrackSection = ({
-    history, currentlyPlaying,
-}: CurrentlyPlayingTrackSectionProps) => (
-    <div
-      className="user-page-section__container border container shadow-sm px-4"
-    >
-        <section className="user-page-section">
-            <h2 className="user-page-section__title">
-                You are listening to
-            </h2>
-            <CurrentlyPlayingTrack
-              history={history}
-              currentlyPlaying={currentlyPlaying}
-            />
-        </section>
-    </div>
-);
+    history,
+}: CurrentlyPlayingTrackSectionProps) => {
+    const [currentlyPlaying, setCurrentlyPlaying] = useState({});
+
+    useEffect(() => {
+        getCurrentUserCurrentlyPlayingTrack().then(track =>
+            setCurrentlyPlaying(track));
+    }, []);
+
+    useInterval(() => {
+        getCurrentUserCurrentlyPlayingTrack().then(track =>
+            setCurrentlyPlaying(track));
+    }, 15000);
+
+    return (
+        <Fragment>
+            { currentlyPlaying.isPlaying &&
+                <div
+                  className="user-page-section__container
+            border container shadow-sm px-4"
+                >
+                    <section className="user-page-section">
+                        <h2 className="user-page-section__title">
+                        You are listening to
+                        </h2>
+                        <CurrentlyPlayingTrack
+                          history={history}
+                          currentlyPlaying={currentlyPlaying}
+                        />
+                    </section>
+                </div>
+            }
+        </Fragment>
+    );
+};
 
 export default CurrentlyPlayingTrackSection;

--- a/src/components/profile/UserPage.js
+++ b/src/components/profile/UserPage.js
@@ -1,12 +1,11 @@
 /* @flow */
 
 import React, { Component, Fragment } from 'react';
-import { Track, PlayHistory, CurrentlyPlaying } from 'spotify-web-sdk';
+import { Track, PlayHistory } from 'spotify-web-sdk';
 
 import {
     getRecentlyPlayedTracks,
     getTopPlayedTracks,
-    getCurrentUserCurrentlyPlayingTrack,
 } from '../../api/SpotifyWebAPI';
 
 import CurrentlyPlayingTrackSection from './CurrentlyPlayingTrackSection';
@@ -21,7 +20,6 @@ type Props = {
 };
 
 type State = {
-    currentlyPlaying: CurrentlyPlaying,
     display: 'TOP' | 'RECENT',
     recentTracks: PlayHistory[],
     topTracks: Track[],
@@ -31,7 +29,6 @@ class UserPage extends Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
-            currentlyPlaying: {},
             display: 'TOP',
             recentTracks: [],
             topTracks: [],
@@ -40,9 +37,6 @@ class UserPage extends Component<Props, State> {
     }
 
     componentDidMount() {
-        getCurrentUserCurrentlyPlayingTrack().then(currentlyPlaying =>
-            this.setState({ currentlyPlaying }));
-
         getRecentlyPlayedTracks().then(recentTracks =>
             this.setState({ recentTracks }));
 
@@ -58,18 +52,16 @@ class UserPage extends Component<Props, State> {
     render() {
         const { history } = this.props;
         const {
-            currentlyPlaying, display, recentTracks, topTracks,
+            display, recentTracks, topTracks,
         } = this.state;
         const tracks = (display === 'TOP' ? topTracks : recentTracks);
 
         if (localStorage.getItem('token')) {
             return (
                 <Fragment>
-                    {currentlyPlaying.isPlaying &&
-                        <CurrentlyPlayingTrackSection
-                          history={history}
-                          currentlyPlaying={currentlyPlaying}
-                        />}
+                    <CurrentlyPlayingTrackSection
+                      history={history}
+                    />
                     <UserTracksSection
                       display={display}
                       history={history}

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,0 +1,24 @@
+import { useRef, useEffect } from 'react';
+
+// Made by Dan Abramov.
+export default function useInterval(callback, delay) {
+    const savedCallback = useRef();
+
+    // Remember the latest callback.
+    useEffect(() => {
+        savedCallback.current = callback;
+    }, [callback]);
+
+    // Set up the interval.
+    useEffect(() => {
+        function tick() {
+            savedCallback.current();
+        }
+        if (delay !== null) {
+            const id = setInterval(tick, delay);
+            return () => clearInterval(id);
+        }
+
+        return null;
+    }, [delay]);
+}


### PR DESCRIPTION
Resolves #46 

Now CurrentlyPlayingTrack updates every 15 seconds without the user needing to reload the page.

**How I made**

I used the `useEffect` hook to set the current track when the component is mounted and I used other hook made my [Dan Abramov](https://overreacted.io/making-setinterval-declarative-with-react-hooks/) to set a interval of 15 seconds to make a new request to the API.

