### PR TITLE
Add spotify as auth provider on backend

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -22,6 +22,7 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
+esproposal.optional_chaining=enable
 
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+

--- a/musicritic/src/components/app/App.js
+++ b/musicritic/src/components/app/App.js
@@ -1,19 +1,43 @@
 /* @flow */
 
-import React from 'react';
+import React, { useState, useEffect, createContext, useContext } from 'react';
 import { ToastContainer } from 'react-toastify';
-
+import type { User } from 'firebase';
 import './App.css';
 
 import Navbar from './Navbar';
 import MainContent from './MainContent';
+import auth from '../../firebase/firebase-config';
 
-const App = () => (
-    <div>
-        <Navbar />
-        <ToastContainer />
-        <MainContent />
-    </div>
-);
+const useCurrentUser = () => {
+    const [user, setUser] = useState(auth.currentUser);
+    useEffect(() => {
+        const unsubscribe = auth.onAuthStateChanged(u => {
+            if (u) {
+                setUser(u);
+            }
+        });
+        return () => unsubscribe();
+    }, []);
+    return user;
+};
+
+const AuthContext = createContext<{ user: User }>({ user: null });
+
+export const useSession = () => {
+    const { user } = useContext(AuthContext);
+    return user;
+};
+
+const App = () => {
+    const user = useCurrentUser();
+    return (
+        <AuthContext.Provider value={{ user }}>
+            <Navbar />
+            <ToastContainer />
+            <MainContent />
+        </AuthContext.Provider>
+    );
+};
 
 export default App;

--- a/musicritic/src/components/app/MainContent.js
+++ b/musicritic/src/components/app/MainContent.js
@@ -24,12 +24,15 @@ const MainContent = () => (
             <SignupPage />
         </ContainerizedRoute>
         <ContainerizedRoute
-          exact
-          path="/search/(tracks|artists|playlists|albums)/:query"
-        >
+            exact
+            path="/search/(tracks|artists|playlists|albums)/:query">
             <SearchResultsPage />
         </ContainerizedRoute>
-        <Route exact path="/auth/:token/:refresh" component={Auth} />
+        <Route
+            exact
+            path="/auth/:token/:refresh/:musicritic"
+            component={Auth}
+        />
         <Route exact path="/album/:id/(reviews|)" component={AlbumPage} />
         <Route exact path="/track/:id" component={TrackPage} />
     </Switch>

--- a/musicritic/src/components/login/Auth.js
+++ b/musicritic/src/components/login/Auth.js
@@ -1,21 +1,21 @@
 /* @flow */
 
-import React, { Component } from 'react';
-import { Redirect } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Redirect, useParams } from 'react-router-dom';
+import { signInWithToken } from '../../firebase/auth';
+import { useSession } from '../app/App';
 
-type Props = {
-    match: any;
+const Auth = () => {
+    const { token, refresh, musicritic } = useParams();
+    const user = useSession();
+
+    useEffect(() => {
+        localStorage.setItem('token', token);
+        localStorage.setItem('refresh', refresh);
+        signInWithToken(atob(musicritic));
+    }, []);
+
+    return user ? <Redirect to="/home" /> : <div>Logging in...</div>;
 };
-
-class Auth extends Component<Props> {
-    componentDidMount() {
-        localStorage.setItem('token', this.props.match.params.token);
-        localStorage.setItem('refresh', this.props.match.params.refresh);
-    }
-
-    render() {
-        return <Redirect to="/home" />;
-    }
-}
 
 export default Auth;

--- a/musicritic/src/components/profile/UserPage.js
+++ b/musicritic/src/components/profile/UserPage.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useState, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import {
@@ -19,24 +19,23 @@ const UserPage = () => {
     const [display, setDisplay] = useState('TOP');
     const [recentTracks] = usePromise(getRecentlyPlayedTracks(), [], []);
     const [topTracks] = usePromise(getTopPlayedTracks(), [], []);
-
     const history = useHistory();
 
     const handleClick = () => {
         setDisplay(display === 'TOP' ? 'RECENT' : 'TOP');
     };
 
-    const tracks = (display === 'TOP' ? topTracks : recentTracks);
+    const tracks = display === 'TOP' ? topTracks : recentTracks;
 
     if (localStorage.getItem('token')) {
         return (
             <Fragment>
                 <CurrentlyPlayingTrackSection history={history} />
                 <UserTracksSection
-                  display={display}
-                  history={history}
-                  onClick={handleClick}
-                  tracks={tracks}
+                    display={display}
+                    history={history}
+                    onClick={handleClick}
+                    tracks={tracks}
                 />
             </Fragment>
         );
@@ -44,7 +43,6 @@ const UserPage = () => {
 
     return <SpotifyConnect />;
 };
-
 
 const SpotifyConnect = () => {
     const serverBaseUri = process.env.SERVER_BASE_URL || '';
@@ -54,8 +52,8 @@ const SpotifyConnect = () => {
             <div className="col-sm-12 col-md-7 col-lg-5">
                 <h1 className="text-center">Connect to Spotify:</h1>
                 <SocialButton
-                  name="spotify"
-                  url={`${serverBaseUri}/auth/login`}
+                    name="spotify"
+                    url={`${serverBaseUri}/auth/login`}
                 />
             </div>
         </div>

--- a/musicritic/src/components/profile/UserPage.js
+++ b/musicritic/src/components/profile/UserPage.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { Fragment, useState, useContext } from 'react';
+import React, { Fragment, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import {

--- a/musicritic/src/firebase/auth.js
+++ b/musicritic/src/firebase/auth.js
@@ -1,8 +1,9 @@
+/* @flow */
+
 import auth from './firebase-config';
 
-export const signInWithEmailAndPassword = (email, password) =>
+export const signInWithEmailAndPassword = (email: string, password: string) =>
     auth.signInWithEmailAndPassword(email, password);
 
-export const getCurrentUser = () => auth().currentUser;
-
-export const getAccessToken = () => getCurrentUser().getIdToken();
+export const signInWithToken = (token: string) =>
+    auth.signInWithCustomToken(token);

--- a/musicritic/src/utils/hooks.js
+++ b/musicritic/src/utils/hooks.js
@@ -1,5 +1,4 @@
 import { useRef, useEffect, useState } from 'react';
-import auth from '../firebase/firebase-config';
 
 export const usePromise = (promise, initialData, deps) => {
     const [data, setData] = useState(initialData);

--- a/musicritic/src/utils/hooks.js
+++ b/musicritic/src/utils/hooks.js
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
+import auth from '../firebase/firebase-config';
 
 export const usePromise = (promise, initialData, deps) => {
     const [data, setData] = useState(initialData);
@@ -6,13 +7,16 @@ export const usePromise = (promise, initialData, deps) => {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        promise.then((result) => {
-            setData(result);
-        }).catch((e) => {
-            setError(e);
-        }).finally(() => {
-            setLoading(false);
-        });
+        promise
+            .then(result => {
+                setData(result);
+            })
+            .catch(e => {
+                setError(e);
+            })
+            .finally(() => {
+                setLoading(false);
+            });
     }, deps);
 
     return [data, error, loading];

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
         "check-format": "prettier -c src/**"
     },
     "dependencies": {
+        "axios": "^0.19.2",
         "body-parser": "^1.18.3",
         "cookie-parser": "^1.4.3",
         "cors": "^2.8.4",
@@ -22,7 +23,7 @@
         "lodash": "^4.17.13",
         "querystring": "^0.2.0",
         "request": "^2.88.0",
-        "spotify-web-sdk": "^0.5.0"
+        "spotify-web-sdk": "^0.5.2"
     },
     "devDependencies": {
         "@babel/cli": "^7.0.0",

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -16,9 +16,11 @@ const config = {};
 
 config.spotify = {
     scope: `user-read-email
+            user-read-private
             user-read-currently-playing
             user-read-recently-played
             user-top-read`,
+    baseUri: 'https://api.spotify.com/v1',
     authBaseUri: 'https://accounts.spotify.com',
     clientId: process.env.SPOTIFY_CLIENT_ID,
     clientSecret: process.env.SPOTIFY_CLIENT_SECRET,

--- a/server/src/firebase/firebaseAuthServices.js
+++ b/server/src/firebase/firebaseAuthServices.js
@@ -1,12 +1,24 @@
 /* @flow */
 
 import { auth } from './firebaseAdmin';
+import { getCurrentUser } from '../spotify/util';
 
 type FirebaseUser = {
     uid: string | null,
     email: string,
     displayName: string,
-}
+};
+
+export const loginWithSpotify = async (userToken: string): Promise<string> => {
+    const userSpotify = await getCurrentUser(userToken);
+    try {
+        await auth.getUser(userSpotify.uid);
+    } catch {
+        await auth.createUser(userSpotify);
+    } finally {
+        return await auth.createCustomToken(userSpotify.uid);
+    }
+};
 
 const userRecordToJson = (userRecord): FirebaseUser => ({
     uid: userRecord.uid,

--- a/server/src/spotify/spotifyAuthController.js
+++ b/server/src/spotify/spotifyAuthController.js
@@ -5,6 +5,7 @@ import querystring from 'querystring';
 import request from 'request';
 
 import config from '../config';
+import { loginWithSpotify } from '../firebase/firebaseAuthServices';
 import {
     generateRandomState,
     getSpotifyAuthUrl,
@@ -19,14 +20,16 @@ const stateKey = 'spotify-auth-state';
 router.get('/login', (req, res) => {
     const state = generateRandomState(16);
     res.cookie(stateKey, state);
-    res.redirect(getSpotifyAuthUrl('/authorize?')
-        + querystring.stringify({
-            response_type: 'code',
-            client_id: config.spotify.clientId,
-            scope: config.spotify.scope,
-            redirect_uri: getHostUrl('/auth/callback'),
-            state,
-        }));
+    res.redirect(
+        getSpotifyAuthUrl('/authorize?') +
+            querystring.stringify({
+                response_type: 'code',
+                client_id: config.spotify.clientId,
+                scope: config.spotify.scope,
+                redirect_uri: getHostUrl('/auth/callback'),
+                state,
+            })
+    );
 });
 
 const requestForSpotifyUserToken = (req, res) => {
@@ -37,13 +40,22 @@ const requestForSpotifyUserToken = (req, res) => {
         redirect_uri: getHostUrl('/auth/callback'),
         grant_type: 'authorization_code',
     });
-    request.post(tokenRequestOptions, (error, response, body) => {
+    request.post(tokenRequestOptions, async (error, response, body) => {
         if (!error && response.statusCode === 200) {
-            res.redirect(getClientUrl(`${config.client.successPath}`
-                + `/${body.access_token}/${body.refresh_token}`));
+            const firebaseToken = await loginWithSpotify(body.access_token);
+            res.redirect(
+                getClientUrl(
+                    `${config.client.successPath}` +
+                        `/${body.access_token}/${
+                            body.refresh_token
+                        }/${Buffer.from(firebaseToken).toString('base64')}`
+                )
+            );
         } else {
-            res.redirect(getClientUrl(config.client.errorPath)
-                + querystring.stringify({ error: 'invalid_token' }));
+            res.redirect(
+                getClientUrl(config.client.errorPath) +
+                    querystring.stringify({ error: 'invalid_token' })
+            );
         }
     });
 };
@@ -52,8 +64,10 @@ router.get('/callback', (req, res) => {
     const { state } = req.query;
     const storedState = req.cookies ? req.cookies[stateKey] : null;
     if (!state || state !== storedState) {
-        res.redirect(getClientUrl(config.client.errorPath)
-            + querystring.stringify({ error: 'state_mismatch' }));
+        res.redirect(
+            getClientUrl(config.client.errorPath) +
+                querystring.stringify({ error: 'state_mismatch' })
+        );
     } else {
         requestForSpotifyUserToken(req, res);
     }

--- a/server/src/spotify/util.js
+++ b/server/src/spotify/util.js
@@ -1,19 +1,23 @@
 /* @flow */
 
 import config from '../config';
+import axios from 'axios';
 
 export const generateRandomState = (length: number) => {
     let state = '';
-    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        + 'abcdefghijklmnopqrstuvwxyz0123456789';
+    const letters =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + 'abcdefghijklmnopqrstuvwxyz0123456789';
     for (let i = 0; i < length; i += 1) {
         state += letters.charAt(Math.floor(Math.random() * letters.length));
     }
     return state;
 };
 
-export const getSpotifyAuthUrl =
-    (urlPath: string) => `${config.spotify.authBaseUri}${urlPath}`;
+export const getSpotifyAuthUrl = (urlPath: string) =>
+    `${config.spotify.authBaseUri}${urlPath}`;
+
+export const getSpotifyUrl = (urlPath: string) =>
+    `${config.spotify.baseUri}${urlPath}`;
 
 export const getHostUrl = (urlPath: string) => {
     if (config.host.production) return `${config.host.baseUri}${urlPath}`;
@@ -26,10 +30,22 @@ export const getClientUrl = (urlPath: string) =>
 const getApplicationToken = () => {
     let tokenToEncrypt = '';
     if (config.spotify.clientId && config.spotify.clientSecret) {
-        tokenToEncrypt =
-            `${config.spotify.clientId}:${config.spotify.clientSecret}`;
+        tokenToEncrypt = `${config.spotify.clientId}:${config.spotify.clientSecret}`;
     }
     return `Basic ${Buffer.from(tokenToEncrypt).toString('base64')}`;
+};
+
+export const getCurrentUser = async (token: string) => {
+    const response = await axios.get(getSpotifyUrl('/me'), {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    return {
+        displayName: response.data.display_name,
+        email: response.data.email,
+        emailVerified: false,
+        photoURL: response.data.images[0]?.url,
+        uid: response.data.uri,
+    };
 };
 
 export const getTokenReqOptions = (form: any) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,6 +2814,13 @@ axios@^0.18.0, axios@^0.18.1:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
@@ -10647,7 +10654,7 @@ split@^1.0.0:
   dependencies:
     through "2"
 
-spotify-web-sdk@^0.5.0:
+spotify-web-sdk@^0.5.0, spotify-web-sdk@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/spotify-web-sdk/-/spotify-web-sdk-0.5.2.tgz#ae0914025239c7af89d4820c2acbf92a7f87d2e9"
   integrity sha512-dLyWj8cbRZSjZAR6KGyxYWeotoFjYImom7h5CoMboLjKw0/Vv/H7KJQia7kBhvPfgBdKlPRPBlgiu07wEeF0jg==


### PR DESCRIPTION
This PR adds the possibility of sign up and sign in on firebase with the Spotify token, now the "Login with Spotify" button creates a new user on firebase (if it doesn't exist) and creates a token for this user which will be returned to the frontend.

I've also created a custom hook `useSession` which returns the info about the current user logged in like it's display name, email and profile pic.

TODO: Save the Spotify user token on firebase in order to fetch user-specific data on the backend in the future. (Also remember to set it as readable only by the token owner on the firebase security rules)

TODO 2: Remove the login and sign up page since we will use only the login with spotify for authentication for now