### PR TITLE
Add logout button on navbar

### DIFF
--- a/musicritic/src/components/app/App.css
+++ b/musicritic/src/components/app/App.css
@@ -12,3 +12,19 @@ body {
 .search {
     margin-left: 1rem;
 }
+
+.logout-button {
+    background-color: black;
+    border: 0.05rem solid white;
+    border-radius: 0.25rem;
+    color: white;
+    margin-left: 2rem;
+    outline: none;
+    padding: 0.5rem 1rem;
+    transition: all 0.3s ease 0s;
+}
+
+.logout-button:hover {
+    color: black;
+    background-color: white;
+}

--- a/musicritic/src/components/app/App.js
+++ b/musicritic/src/components/app/App.js
@@ -15,6 +15,8 @@ const useCurrentUser = () => {
         const unsubscribe = auth.onAuthStateChanged(u => {
             if (u) {
                 setUser(u);
+            } else {
+                setUser(null);
             }
         });
         return () => unsubscribe();

--- a/musicritic/src/components/app/Navbar.js
+++ b/musicritic/src/components/app/Navbar.js
@@ -3,13 +3,24 @@
 import React from 'react';
 import { NavLink, useHistory } from 'react-router-dom';
 
+import { useSession } from '../app/App';
+import { signOut } from '../../firebase/auth';
 import SearchInput from '../search/SearchInput';
 
 const Navbar = () => {
     const history = useHistory();
+    const user = useSession();
 
     const handleSearch = query => {
         history.push(`/search/tracks/${query}`);
+    };
+
+    const handleLogout = () => {
+        signOut().then(() => {
+            localStorage.removeItem('token');
+            localStorage.removeItem('refresh');
+            history.push('/home');
+        });
     };
 
     return (
@@ -32,6 +43,7 @@ const Navbar = () => {
                     <ul className="navbar-nav ml-auto">
                         <NavbarItem text="Home" href="/home" />
                     </ul>
+                    { user && <LogoutButton handleLogout={handleLogout}/> }
                 </div>
             </div>
         </nav>
@@ -64,5 +76,14 @@ const NavbarLink = ({ text, href, brand }: NavbarLinkProps) => (
 NavbarLink.defaultProps = {
     brand: false,
 }
+
+type LogoutButtonProps = {
+    handleLogout: () => void
+};
+
+const LogoutButton = ({ handleLogout }: LogoutButtonProps) =>
+        <button type='button' className='logout-button' onClick={handleLogout}>
+            Logout
+        </button>
 
 export default Navbar;

--- a/musicritic/src/firebase/auth.js
+++ b/musicritic/src/firebase/auth.js
@@ -7,3 +7,5 @@ export const signInWithEmailAndPassword = (email: string, password: string) =>
 
 export const signInWithToken = (token: string) =>
     auth.signInWithCustomToken(token);
+
+export const signOut = () => auth.signOut();


### PR DESCRIPTION
- **Issue:** Resolves #48 
- **Description:** As described on the issue, users couldn't logout from their accounts in Musicritic nor switch accounts. This PR adds a logout button on the navigation bar (right after the NavLinks) that will allow the account logout. Also, the `useSession` hook received a minor fix to keep its consistency after logouts.