### PR TITLE
Recreate Rating component

### DIFF
--- a/musicritic/src/components/album/summary/AlbumData.css
+++ b/musicritic/src/components/album/summary/AlbumData.css
@@ -27,6 +27,9 @@
     border-width: 1px;
     padding-top: .5rem;
     padding-bottom: .5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .album-rating--positive {

--- a/musicritic/src/components/album/summary/AlbumData.js
+++ b/musicritic/src/components/album/summary/AlbumData.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { Album } from 'spotify-web-sdk';
 
 import './AlbumData.css';
+import Rating from '../../common/rating/Rating';
 
 type Props = {
     album: Album,
@@ -35,44 +36,37 @@ type AlbumRatingsProps = {
     userRating: number,
 };
 
-const AlbumRatings = ({ averageRating, userRating }: AlbumRatingsProps) => {
-    const ratingEval = (rating: number) => {
-        if (rating > 3.0) return 'positive';
-        else if (rating >= 2.0) return 'mixed';
-        return 'negative';
-    };
-
-    return (
-        <div className="album-ratings row">
-            <AlbumRating
-              rating={averageRating}
-              ratingEval={ratingEval}
-              title="Average rating"
-            />
-            <AlbumRating
-              rating={userRating}
-              ratingEval={ratingEval}
-              title="Your rating"
-            />
-        </div>
-    );
-};
+const AlbumRatings = ({ averageRating, userRating }: AlbumRatingsProps) => (
+    <div className="album-ratings row">
+        <AlbumRating
+            rating={averageRating}
+            title="Average rating"
+            displayOnly
+        />
+        <AlbumRating
+            rating={userRating}
+            title="Your rating"
+        />
+    </div>
+);
 
 type AlbumRatingProps = {
     rating: number,
-    ratingEval: (number) => string,
     title: string,
+    displayOnly?: boolean,
 };
 
-const AlbumRating = ({ rating, ratingEval, title }: AlbumRatingProps) => (
-    <div className={`album-rating album-rating--${ratingEval(rating)} col-4`}>
+const AlbumRating = ({ rating, title, displayOnly }: AlbumRatingProps) => (
+    <div className="album-rating col-4">
         <p className="album-rating__title">
             {title}
         </p>
-        <h3 className="album-rating__value">
-            {rating}
-        </h3>
+        <Rating initialValue={rating} displayOnly={displayOnly} />
     </div>
 );
+
+AlbumRating.defaultProps = {
+    displayOnly: false,
+}
 
 export default AlbumData;

--- a/musicritic/src/components/common/rating/Rating.css
+++ b/musicritic/src/components/common/rating/Rating.css
@@ -1,0 +1,23 @@
+.rating {
+  display: grid;
+  width: fit-content;
+  grid-template-columns: repeat(5, 1fr);
+}
+
+.rating-star {
+  position: relative;
+}
+
+.rating-star-container {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.rating-star-half {
+  outline: none;
+  cursor: pointer;
+}

--- a/musicritic/src/components/common/rating/Rating.js
+++ b/musicritic/src/components/common/rating/Rating.js
@@ -1,54 +1,84 @@
 /* @flow */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+
+import './Rating.css';
 
 type Props = {
-    value: number,
+    initialValue: number,
+    displayOnly?: boolean,
 }
 
-const Rating = (props: Props) => {
-    const [value, setValue] = useState(props.value);
-
-    const handleClick = newValue => {
-        setValue(newValue);
-    };
-
+const Rating = ({ initialValue, displayOnly }: Props) => {
+    const [value, setValue] = useState(initialValue);
+    const [hoverValue, setHoverValue] = useState(0);
+    
+    const [displayValue, setDisplayValue] = useState(initialValue);
+    useEffect(() => {
+        if (hoverValue) {
+            setDisplayValue(hoverValue);
+        } else {
+            setDisplayValue(value);
+        }
+    }, [value, hoverValue]);
+    
     const stars = [];
 
-    for (let i = 0; i < 5; i += 1) {
-        if (value >= i + 1) {
-            stars.push(<SolidStar handleClick={() => handleClick(i + 1)} />);
-        } else if (value >= i + 0.5) {
-            stars.push(<StarHalf handleClick={() => handleClick(i + 1)} />);
-        } else {
-            stars.push(<RegularStar handleClick={() => handleClick(i + 1)} />);
-        }
+    for (let index = 0; index < 5; index += 1) {
+        stars.push(
+            <RatingStar
+                key={index}
+                index={index}
+                displayValue={displayValue}
+                setValue={setValue}
+                setHoverValue={setHoverValue}
+                displayOnly={displayOnly}
+            />
+        );
     }
 
-    return <div>{stars}</div>;
+    return <div className="rating" onMouseLeave={() => setHoverValue(0)}>{stars}</div>;
 };
 
-const clickableProps = handleClick => ({
-    onClick: handleClick,
-    tabIndex: 0,
-    onKeyPress: () => {},
-    role: 'button',
-});
-
-type StarProps = {
-    handleClick: () => void,
+Rating.defaultProps = {
+    displayOnly: false,
 }
 
-const SolidStar = ({ handleClick }: StarProps) => (
-    <i className="fas fa-star" {...clickableProps(handleClick)} />
-);
+type StarProps = {
+    index: number,
+    displayValue: number,
+    setValue: (value: number) => void,
+    setHoverValue: (value: number) => void,
+    displayOnly: boolean,
+}
 
-const RegularStar = ({ handleClick }: StarProps) => (
-    <i className="far fa-star" {...clickableProps(handleClick)} />
-);
+const RatingStar = ({ index, displayValue, setValue, setHoverValue, displayOnly }: StarProps) => {
+    let iconClassName;
+    if (displayValue >= index + 1) { 
+        iconClassName = 'fas fa-star';
+    } else if (displayValue === index + 0.5) {
+        iconClassName = 'fas fa-star-half-alt';
+    } else {
+        iconClassName = 'far fa-star';
+    }
 
-const StarHalf = ({ handleClick }: StarProps) => (
-    <i className="fas fa-star-half-alt" {...clickableProps(handleClick)} />
-);
+    const starHalfProps = (modifier: number) => ({
+        onClick: () => setValue(index + modifier),
+        onMouseOver: () => setHoverValue(index + modifier),
+        className: 'rating-star-half',
+        tabIndex: 0,
+        role: 'button',
+    });
+
+    return (
+        <div className="rating-star" key={index}>
+            <div className="rating-star-container">
+                <span {...displayOnly ? {} : starHalfProps(0.5)} />
+                <span {...displayOnly ? {} : starHalfProps(1)}  />
+            </div>
+            <i className={iconClassName} />
+        </div>
+    );
+}
 
 export default Rating;

--- a/musicritic/src/components/common/rating/Rating.js
+++ b/musicritic/src/components/common/rating/Rating.js
@@ -49,7 +49,7 @@ type StarProps = {
     displayValue: number,
     setValue: (value: number) => void,
     setHoverValue: (value: number) => void,
-    displayOnly: boolean,
+    displayOnly?: boolean,
 }
 
 const RatingStar = ({ index, displayValue, setValue, setHoverValue, displayOnly }: StarProps) => {
@@ -79,6 +79,10 @@ const RatingStar = ({ index, displayValue, setValue, setHoverValue, displayOnly 
             <i className={iconClassName} />
         </div>
     );
+}
+
+RatingStar.defaultProps = {
+    displayOnly: false,
 }
 
 export default Rating;

--- a/musicritic/src/components/track/TrackPage.css
+++ b/musicritic/src/components/track/TrackPage.css
@@ -52,3 +52,13 @@
     width: 25%;
     border-radius: 2%;
 }
+
+.track-rating-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.track-page-body {
+    margin-top: 2.5rem;
+}

--- a/musicritic/src/components/track/TrackPage.js
+++ b/musicritic/src/components/track/TrackPage.js
@@ -21,7 +21,8 @@ const TrackPage = () => {
         getTrackFromAPI();
     }, []);
 
-    return track.name ? <><TrackPageHeader track={track} /><TrackPageBody /></> : <div />;
+    // TODO Use actual values
+    return track.name ? <><TrackPageHeader track={track} /><TrackPageBody userRating={4} averageRating={3.5} /></> : null;
 };
 
 export default TrackPage;

--- a/musicritic/src/components/track/TrackPage.js
+++ b/musicritic/src/components/track/TrackPage.js
@@ -4,6 +4,9 @@ import { useParams } from 'react-router-dom';
 
 import { getTrack } from '../../api/SpotifyWebAPI';
 import TrackPageHeader from './TrackPageHeader';
+import TrackPageBody from './TrackPageBody';
+
+import './TrackPage.css';
 
 const TrackPage = () => {
     const [track, setTrack] = useState({});
@@ -18,7 +21,7 @@ const TrackPage = () => {
         getTrackFromAPI();
     }, []);
 
-    return track.name ? <TrackPageHeader track={track} /> : <div />;
+    return track.name ? <><TrackPageHeader track={track} /><TrackPageBody /></> : <div />;
 };
 
 export default TrackPage;

--- a/musicritic/src/components/track/TrackPageBody.js
+++ b/musicritic/src/components/track/TrackPageBody.js
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const TrackPageBody = ({ userRating, averageRating }: Props) => (
-    <div className="container">
+    <div className="track-page-body container">
         <TrackRating userRating={userRating} averageRating={averageRating} />
     </div>
 );
@@ -23,22 +23,27 @@ type TrackRatingProps = {
 const TrackRating = ({ userRating, averageRating }: TrackRatingProps) => (
     <div className="padding row justify-content-md-center text-center">
         <TrackRatingColumn rating={userRating} title="YOUR RATING" />
-        <TrackRatingColumn rating={averageRating} title="AVERAGE RATING" />
+        <TrackRatingColumn rating={averageRating} title="AVERAGE RATING" displayOnly />
     </div>
 );
 
 type TrackRatingColumnProps = {
     rating: number,
     title: string,
+    displayOnly?: boolean,
 };
 
-const TrackRatingColumn = ({ rating, title }: TrackRatingColumnProps) => (
-    <div className="col-md-auto border padding">
-        <h5 className="rating-title">{title}</h5>
-        <h5>
-            <Rating value={rating} />
+const TrackRatingColumn = ({ rating, title, displayOnly }: TrackRatingColumnProps) => (
+    <div className="track-rating-col col-md-auto border padding">
+        <h5>{title}</h5>
+        <h5 className="text-center">
+            <Rating initialValue={rating} displayOnly={displayOnly} />
         </h5>
     </div>
 );
+
+TrackRatingColumn.defaultProps = {
+    displayOnly: false,
+}
 
 export default TrackPageBody;

--- a/musicritic/src/components/track/TrackPageHeader.js
+++ b/musicritic/src/components/track/TrackPageHeader.js
@@ -6,8 +6,6 @@ import { Track } from 'spotify-web-sdk';
 import CustomPalette from '../common/palette/CustomPalette';
 import SocialButton from '../common/social-button/SocialButton';
 
-import './TrackPageHeader.css';
-
 type Props = {
     track: Track,
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build": "lerna run build --stream",
         "lint": "lerna run lint --stream",
         "check-format": "lerna run check-format --stream",
-        "format": "prettier src/** --write",
+        "format": "lerna run format --stream",
         "check-flow": "lerna run check-flow --stream"
     },
     "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
         "start": "nodemon src/index.js --exec babel-node",
         "build": "babel src --out-dir dist/ --ignore node_modules/",
         "check-flow": "flow check .",
-        "format": "lerna run format --stream",
+        "format": "prettier src/** --write",
         "check-format": "prettier -c src/**"
     },
     "dependencies": {


### PR DESCRIPTION
This PR recreates our Rating component. It now fully supports hovering and half-star ratings, and it's used in Track and Album pages.

### Track
![image](https://user-images.githubusercontent.com/20714148/95026653-442c0380-0669-11eb-9fb3-eff9b1249872.png)

### Album
![image](https://user-images.githubusercontent.com/20714148/95026605-eac3d480-0668-11eb-8e61-1861d0fa4480.png)

Fixes #70 