### PR TITLE
Add section for displaying reviews

### DIFF
--- a/musicritic/src/components/common/section-header/SectionHeader.css
+++ b/musicritic/src/components/common/section-header/SectionHeader.css
@@ -1,0 +1,38 @@
+.section-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    padding: 1rem;
+}
+
+.complete-header {
+    align-items: flex-start;
+}
+
+.text-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    min-width: 70%;
+}
+
+.section-title {
+    font-size: 2rem;
+    font-weight: bold;
+}
+
+.section-subtitle {
+    color: #4f4f4f;
+    font-size: 1.1rem;
+    margin-top: 0.25rem;
+    padding-left: 0.25rem;
+}
+
+.children-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0.5rem;
+    width: 100%;
+}

--- a/musicritic/src/components/common/section-header/SectionHeader.js
+++ b/musicritic/src/components/common/section-header/SectionHeader.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+import React from 'react';
+
+import './SectionHeader.css';
+
+type SectionHeaderProps = {
+    title: string,
+    subtitle?: string | null,
+    children?: Object | null,
+};
+
+const SectionHeader = ({ title, subtitle, children }: SectionHeaderProps) => (
+    <div
+        className={`section-header ${
+            subtitle && children ? 'complete-header' : ''
+        }`}>
+        <div className="text-wrapper">
+            <span className="section-title">{title}</span>
+            {subtitle && <span className="section-subtitle">{subtitle}</span>}
+        </div>
+        {children && <div className="children-wrapper">{children}</div>}
+    </div>
+);
+
+SectionHeader.defaultProps = {
+    subtitle: null,
+    children: null,
+};
+
+export default SectionHeader;

--- a/musicritic/src/components/review/ReviewSection.css
+++ b/musicritic/src/components/review/ReviewSection.css
@@ -1,0 +1,86 @@
+.bold-text {
+    font-weight: bold;
+}
+
+.round-cropped {
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.compose-review-button {
+    background-color: black;
+    border: 0.05rem solid black;
+    border-radius: 0.25rem;
+    color: white;
+    font-size: 1rem;
+    opacity: 0.7;
+    outline: none;
+    padding: 0.5rem 1rem;
+    transition: all 0.3s ease 0s;
+}
+
+.compose-review-button:hover {
+    color: black;
+    background-color: inherit;
+}
+
+.reviews-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 0 1.5rem 0 1rem;
+}
+
+.review-card {
+    border: 0.05rem solid black;
+    border-radius: 0.1rem;
+    margin-bottom: 2rem;
+    width: 100%;
+}
+
+.review-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: black;
+    color: white;
+    font-size: 1rem;
+    opacity: 0.7;
+    padding: 0.5rem 1rem 0.5rem 0.5rem;
+}
+
+.review-user-info {
+    display: flex;
+    align-items: center;
+}
+
+.review-user-photo {
+    height: 2.5rem;
+    margin-right: 0.75rem;
+    opacity: 1;
+}
+
+.review-text-area {
+    padding: 0.5rem 1rem;
+    text-align: justify;
+}
+
+.change-text-button {
+    border: none;
+    background-color: inherit;
+    font-weight: bold;
+    margin-left: 0.5rem;
+}
+
+.change-text-button:hover {
+    text-decoration: underline;
+}
+
+.review-details-info {
+    background-color: black;
+    color: white;
+    font-size: 0.9rem;
+    opacity: 0.7;
+    padding: 0.5rem 1rem 0.5rem 0.5rem;
+}

--- a/musicritic/src/components/review/ReviewSection.js
+++ b/musicritic/src/components/review/ReviewSection.js
@@ -1,0 +1,132 @@
+/* @flow */
+
+import React, { useState } from 'react';
+
+import SectionHeader from '../common/section-header/SectionHeader';
+
+import './ReviewSection.css';
+
+const formatDate = (date: string) => {
+    const daySuffixes = ['th', 'st', 'nd', 'rd'];
+    const monthNames = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+    ];
+
+    const d = new Date(date);
+    const month = monthNames[d.getMonth()];
+    const daySuffix =
+        d.getDate() < 3 ? daySuffixes[d.getDate()] : daySuffixes[0];
+
+    return `${month} ${d.getDate()}${daySuffix}, ${d.getFullYear()}`;
+};
+
+type ReviewSectionProps = {
+    reviews: Object,
+};
+
+const ReviewSection = ({ reviews }: ReviewSectionProps) => (
+    <div className="review-section">
+        <SectionHeader title="User Reviews">
+            <ComposeReviewButton />
+        </SectionHeader>
+        <div className="reviews-wrapper">
+            {reviews.map(review => (
+                <ReviewCard key={review.id} {...review} />
+            ))}
+        </div>
+    </div>
+);
+
+const ComposeReviewButton = () => {
+    const handleClick = () => {};
+
+    return (
+        <button
+            type="button"
+            className="compose-review-button"
+            onClick={handleClick}>
+            Compose Review
+        </button>
+    );
+};
+
+type ReviewCardProps = {
+    userName: string,
+    userPhoto: string,
+    rating: number,
+    text: string,
+    date: string,
+};
+
+const ReviewCard = ({
+    userName,
+    userPhoto,
+    rating,
+    text,
+    date,
+}: ReviewCardProps) => {
+    const isLongReview = text.length > 500;
+    const reviewDate = formatDate(date);
+
+    const [displayedText, setDisplayedText] = useState(
+        isLongReview ? `${text.substring(0, 497)}...` : text
+    );
+
+    const onShowMore = () => {
+        setDisplayedText(text);
+    };
+
+    const onShowLess = () => {
+        setDisplayedText(`${text.substring(0, 247)}...`);
+    };
+
+    return (
+        <div className="review-card">
+            <div className="review-card-header">
+                <div className="review-user-info">
+                    <img
+                        className="review-user-photo round-cropped"
+                        src={userPhoto}
+                        alt={`${userName}`}
+                    />
+                    <span className="review-user-name">
+                        <span className="bold-text">{userName}</span> &apos;s
+                        review
+                    </span>
+                </div>
+                <span className="review-rating">
+                    Rated <span className="bold-text">{rating}</span>
+                </span>
+            </div>
+            <div className="review-text-area">
+                <span className="review-text">{displayedText}</span>
+                {isLongReview && displayedText !== text && (
+                    <button className="change-text-button" onClick={onShowMore}>
+                        Show More
+                    </button>
+                )}
+                {isLongReview && displayedText === text && (
+                    <button className="change-text-button" onClick={onShowLess}>
+                        Show Less
+                    </button>
+                )}
+            </div>
+            <div className="review-details-info">
+                <span className="review-date">{reviewDate}</span>
+            </div>
+        </div>
+    );
+};
+
+export default ReviewSection;


### PR DESCRIPTION
- **Issue:** Resolves #79 
- **Description:** As asked on the issue, this pull request adds two main components: `SectionHeader` and` ReviewsSection`. The first one creates a header for the sections of Musicritic pages. For this, the section title, an optional subtitle and optional children components (such as buttons) are used. The second component defines the section where the reviews will be displayed (for music and albums). The `ReviewsSection` design is like the one presented on the issue.