### PR TITLE
Add route for current user's track review retrieving

### DIFF
--- a/server/src/track-reviews/trackReviewController.js
+++ b/server/src/track-reviews/trackReviewController.js
@@ -3,9 +3,24 @@
 import express from 'express';
 import { uniqueId } from 'lodash';
 import checkAuth from '../firebase/firebaseAuthHandler';
-import { createTrackReview } from './trackReviewCollections';
+import {
+    createTrackReview,
+    getUserTrackReview,
+} from './trackReviewCollections';
 
 const router = express.Router();
+
+router.get('/track/:id/reviews/me', checkAuth, (req, res) => {
+    const trackId = req.params.id;
+    const authorUid = req.user.uid;
+    getUserTrackReview(trackId, authorUid)
+        .then(reviews => {
+            reviews.size === 0
+                ? res.status(204).send()
+                : res.status(200).send(reviews.docs[0]);
+        })
+        .catch(error => res.status(error.status).send(error));
+});
 
 router.post('/track/:id/reviews', checkAuth, (req, res) => {
     const review = req.body;


### PR DESCRIPTION
- **Issue:** Resolves #85 
- **Description:** Using `GET track/:id/reviews/me`, is now possible to retrieve the current user's review for the track identified by `:id`. If the user never reviewed this track, a `204 No Content` HTTP status code will be returned. Otherwise, this endpoint will return a JSON with the following schema:

  ```graphql
  TrackReview {
      id: string,
      authorUid: string.
      trackId: string,
      rating: number,
      review?: string,
  }
  ```
