### PR TITLE
Add route to update track reviews

### DIFF
--- a/server/src/track-reviews/trackReviewCollections.js
+++ b/server/src/track-reviews/trackReviewCollections.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import { reduce } from 'lodash';
 import { db } from '../firebase/firebaseAdmin';
 
 type TrackReviewModel = {

--- a/server/src/track-reviews/trackReviewCollections.js
+++ b/server/src/track-reviews/trackReviewCollections.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { reduce } from 'lodash';
 import { db } from '../firebase/firebaseAdmin';
 
 type TrackReviewModel = {
@@ -33,4 +34,32 @@ export const getUserTrackReview = (trackId: string, authorUid: string) => {
     return TrackReviews.where('authorUid', '==', authorUid)
         .where('trackId', '==', trackId)
         .get();
+};
+
+export const updateUserTrackReview = async (
+    reviewId: string,
+    updatedTrackReview: TrackReviewModel
+) => {
+    const ref = TrackReviews.doc(reviewId);
+    const review = (await ref.get()).data();
+    if (!review)
+        throw {
+            status: 500,
+            message: 'Review not found',
+        };
+
+    if (updatedTrackReview.authorUid !== review.authorUid)
+        throw {
+            status: 500,
+            message: 'Not authorized to edit review from others',
+        };
+
+    if (updatedTrackReview.trackId !== review.trackId)
+        throw {
+            status: 500,
+            message: 'Cannot change the track which is being reviewed',
+        };
+
+    ref.set(updatedTrackReview);
+    return updatedTrackReview;
 };

--- a/server/src/track-reviews/trackReviewController.js
+++ b/server/src/track-reviews/trackReviewController.js
@@ -6,12 +6,13 @@ import checkAuth from '../firebase/firebaseAuthHandler';
 import {
     createTrackReview,
     getUserTrackReview,
+    updateUserTrackReview,
 } from './trackReviewCollections';
 
 const router = express.Router();
 
-router.get('/track/:id/reviews/me', checkAuth, (req, res) => {
-    const trackId = req.params.id;
+router.get('/track/:trackId/reviews/me', checkAuth, (req, res) => {
+    const trackId = req.params.trackId;
     const authorUid = req.user.uid;
     getUserTrackReview(trackId, authorUid)
         .then(reviews => {
@@ -22,12 +23,22 @@ router.get('/track/:id/reviews/me', checkAuth, (req, res) => {
         .catch(error => res.status(error.status).send(error));
 });
 
-router.post('/track/:id/reviews', checkAuth, (req, res) => {
+router.post('/track/:trackId/reviews', checkAuth, (req, res) => {
     const review = req.body;
-    review.trackId = req.params.id;
+    review.trackId = req.params.trackId;
     review.authorUid = req.user.uid;
     createTrackReview(review)
         .then(review => res.status(201).send(review))
+        .catch(error => res.status(error.status).send(error));
+});
+
+router.put('/track/:trackId/reviews/:reviewId', checkAuth, (req, res) => {
+    const review = req.body;
+    review.trackId = req.params.trackId;
+    review.id = req.params.reviewId;
+    review.authorUid = req.user.uid;
+    updateUserTrackReview(review.id, review)
+        .then(review => res.status(200).send(review))
         .catch(error => res.status(error.status).send(error));
 });
 


### PR DESCRIPTION
This PR creates the endpoint `PUT /track/:trackId/reviews/:reviewId` to update track reviews, in order to do it, you need to pass a JSON with this schema:

```graphql
TrackReview {
    rating: number,
    review?: string,
}
```

and it will return a JSON with this schema:

```graphql
TrackReview {
    id: string,
    authorUid: string.
    trackId: string,
    rating: number,
    review?: string,
}
```

OBS: The update strategy substitute all the values for the new ones, so, you should pass all the values, including the ones that not changed in the body or the field will be removed

OBS²: The endpoint do not allow to edit the trackId, reviewId not authorId, and do not allow users to edit reviews made by others

resolves #87 