### PR TITLE
Redirect / route to the correct page

### DIFF
--- a/musicritic/src/components/app/MainContent.js
+++ b/musicritic/src/components/app/MainContent.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import ContainerizedRoute from './routes/ContainerizedRoute';
 
-import LoginPage from '../login/LoginPage';
 import UserPage from '../profile/UserPage';
 import Auth from '../login/Auth';
 import AlbumPage from '../album/AlbumPage';

--- a/musicritic/src/components/app/MainContent.js
+++ b/musicritic/src/components/app/MainContent.js
@@ -15,7 +15,7 @@ import TrackPage from '../track/TrackPage';
 const MainContent = () => (
     <Switch>
         <ContainerizedRoute exact path="/">
-            <LoginPage />
+            <UserPage />
         </ContainerizedRoute>
         <ContainerizedRoute exact path="/home">
             <UserPage />

--- a/server/src/track-reviews/trackReviewController.js
+++ b/server/src/track-reviews/trackReviewController.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import express from 'express';
-import { uniqueId } from 'lodash';
 import checkAuth from '../firebase/firebaseAuthHandler';
 import {
     createTrackReview,


### PR DESCRIPTION
We changed our main auth method (and only) to be with the spotify account, and no more accept creating accounts with email or other methods, so is fair to remove the / to be now the UserPage which shows the spotify login instead of the signin page.

Before:

![image](https://user-images.githubusercontent.com/11728746/97765571-62aede80-1af1-11eb-94c9-a37131336145.png)


Now:

![image](https://user-images.githubusercontent.com/11728746/97765585-6fcbcd80-1af1-11eb-8711-db9a62bc2214.png)
