### PR TITLE
Add loading state to pages

### DIFF
--- a/musicritic/src/api/SpotifyWebAPI.js
+++ b/musicritic/src/api/SpotifyWebAPI.js
@@ -3,9 +3,6 @@
 import * as spotify from 'spotify-web-sdk';
 import { userApi } from './UserAPI';
 
-const token = localStorage.getItem('spotifyToken') || '';
-
-const refreshToken = localStorage.getItem('spotifyRefresh') || '';
 const refreshTokenFunction = async (): Promise<string> => {
     const { data } = await userApi.post('/auth/refresh', {
         refresh_token: refreshToken,
@@ -14,7 +11,13 @@ const refreshTokenFunction = async (): Promise<string> => {
     return data.token;
 };
 
-spotify.init({ token, refreshToken, refreshTokenFunction });
+export const init = (spotifyToken?: string, spotifyRefreshToken?: string) => {
+    const token = spotifyToken || localStorage.getItem('spotifyToken') || '';
+    const refreshToken = spotifyRefreshToken || localStorage.getItem('spotifyRefresh') || '';
+    spotify.init({ token, refreshToken, refreshTokenFunction });
+};
+
+init();
 
 export const getRecentlyPlayedTracks = () =>
     spotify

--- a/musicritic/src/api/SpotifyWebAPI.js
+++ b/musicritic/src/api/SpotifyWebAPI.js
@@ -3,7 +3,7 @@
 import * as spotify from 'spotify-web-sdk';
 import { userApi } from './UserAPI';
 
-const refreshTokenFunction = async (): Promise<string> => {
+const refreshTokenFunction = async (refreshToken: string): Promise<string> => {
     const { data } = await userApi.post('/auth/refresh', {
         refresh_token: refreshToken,
     });
@@ -14,7 +14,7 @@ const refreshTokenFunction = async (): Promise<string> => {
 export const init = (spotifyToken?: string, spotifyRefreshToken?: string) => {
     const token = spotifyToken || localStorage.getItem('spotifyToken') || '';
     const refreshToken = spotifyRefreshToken || localStorage.getItem('spotifyRefresh') || '';
-    spotify.init({ token, refreshToken, refreshTokenFunction });
+    spotify.init({ token, refreshToken, refreshTokenFunction: refreshTokenFunction(refreshToken) });
 };
 
 init();

--- a/musicritic/src/components/common/loading/Loading.css
+++ b/musicritic/src/components/common/loading/Loading.css
@@ -1,0 +1,5 @@
+.spinner {
+  height: 10rem;
+  width: 10rem;
+  border-width: 1rem;
+}

--- a/musicritic/src/components/common/loading/Loading.js
+++ b/musicritic/src/components/common/loading/Loading.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+import React from 'react';
+
+import './Loading.css';
+
+const Loading = () => (
+  <div className="album-page container p-5">
+    <div className="d-flex justify-content-center">
+      <div className="spinner spinner-border" role="status">
+        <span className="sr-only">Loading...</span>
+      </div>
+    </div>
+  </div>
+);
+
+export default Loading;

--- a/musicritic/src/components/login/Auth.js
+++ b/musicritic/src/components/login/Auth.js
@@ -1,14 +1,17 @@
 /* @flow */
 
 import React, { useEffect } from 'react';
-import { Redirect, useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 
 import { signInWithToken } from '../../firebase/auth';
 import { useSession } from '../app/App';
 
+import Loading from '../common/loading/Loading';
+
 const Auth = () => {
     const { token, refresh, musicritic } = useParams();
     const user = useSession();
+    const history = useHistory();
 
     useEffect(() => {
         const login = async () => {
@@ -23,7 +26,11 @@ const Auth = () => {
         login();
     }, []);
 
-    return user ? <Redirect to="/home" /> : <div>Logging in...</div>;
+    if (user && localStorage.getItem('spotifyToken')) { 
+        history.push('/home');
+    } 
+
+    return <Loading />;
 };
 
 export default Auth;

--- a/musicritic/src/components/profile/CurrentlyPlayingTrackSection.js
+++ b/musicritic/src/components/profile/CurrentlyPlayingTrackSection.js
@@ -1,18 +1,15 @@
 /* @flow */
 
 import React, { useState, useEffect, Fragment } from 'react';
+import { useHistory } from 'react-router-dom';
+
 import { getCurrentUserCurrentlyPlayingTrack } from '../../api/SpotifyWebAPI';
 import { useInterval } from '../../utils/hooks';
 import CurrentlyPlayingTrack from './CurrentlyPlayingTrack';
 
-type CurrentlyPlayingTrackSectionProps = {
-    history: any,
-};
-
-const CurrentlyPlayingTrackSection = ({
-    history,
-}: CurrentlyPlayingTrackSectionProps) => {
+const CurrentlyPlayingTrackSection = () => {
     const [currentlyPlaying, setCurrentlyPlaying] = useState({});
+    const history = useHistory();
 
     useEffect(() => {
         getCurrentUserCurrentlyPlayingTrack().then(track =>

--- a/musicritic/src/components/profile/UserPage.js
+++ b/musicritic/src/components/profile/UserPage.js
@@ -13,7 +13,7 @@ const UserPage = () => {
     const spotifyToken = localStorage.getItem('spotifyToken');
     const spotifyRefreshToken = localStorage.getItem('spotifyRefresh');
     
-    if (spotifyToken) {
+    if (spotifyToken && spotifyRefreshToken) {
         init(spotifyToken, spotifyRefreshToken);
         return (
             <Fragment>

--- a/musicritic/src/components/profile/UserPage.js
+++ b/musicritic/src/components/profile/UserPage.js
@@ -1,42 +1,24 @@
 /* @flow */
-import React, { Fragment, useState } from 'react';
-import { useHistory } from 'react-router-dom';
-
-import {
-    getRecentlyPlayedTracks,
-    getTopPlayedTracks,
-} from '../../api/SpotifyWebAPI';
+import React, { Fragment } from 'react';
 
 import CurrentlyPlayingTrackSection from './CurrentlyPlayingTrackSection';
 import UserTracksSection from './UserTracksSection';
 
 import SocialButton from '../common/social-button/SocialButton';
+import { init } from '../../api/SpotifyWebAPI';
 
 import './UserPage.css';
-import { usePromise } from '../../utils/hooks';
 
 const UserPage = () => {
-    const [display, setDisplay] = useState('TOP');
-    const [recentTracks] = usePromise(getRecentlyPlayedTracks(), [], []);
-    const [topTracks] = usePromise(getTopPlayedTracks(), [], []);
-    const history = useHistory();
-
-    const handleClick = () => {
-        setDisplay(display === 'TOP' ? 'RECENT' : 'TOP');
-    };
-
-    const tracks = display === 'TOP' ? topTracks : recentTracks;
-
-    if (localStorage.getItem('spotifyToken')) {
+    const spotifyToken = localStorage.getItem('spotifyToken');
+    const spotifyRefreshToken = localStorage.getItem('spotifyRefresh');
+    
+    if (spotifyToken) {
+        init(spotifyToken, spotifyRefreshToken);
         return (
             <Fragment>
-                <CurrentlyPlayingTrackSection history={history} />
-                <UserTracksSection
-                    display={display}
-                    history={history}
-                    onClick={handleClick}
-                    tracks={tracks}
-                />
+                <CurrentlyPlayingTrackSection />
+                <UserTracksSection />
             </Fragment>
         );
     }

--- a/musicritic/src/components/profile/UserTracksSection.js
+++ b/musicritic/src/components/profile/UserTracksSection.js
@@ -1,33 +1,43 @@
 /* @flow */
 
-import React from 'react';
-import { Track, PlayHistory } from 'spotify-web-sdk';
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+    getRecentlyPlayedTracks,
+    getTopPlayedTracks,
+} from '../../api/SpotifyWebAPI';
 
 import TrackCarousel from './TopTracksCarousel';
 import RecentTracksCarousel from './RecentTracksCarousel';
 
 import './UserTracksSection.css';
+import Loading from '../common/loading/Loading';
+import { usePromise } from '../../utils/hooks';
 
-type Props = {
-    display: string,
-    history: any,
-    onClick: (display: string) => void,
-    tracks: Track[] | PlayHistory[],
+const UserTracksSection = () => {
+    const [display, setDisplay] = useState('TOP');
+    const [recentTracks, , loadingRecent] = usePromise(getRecentlyPlayedTracks(), [], []);
+    const [topTracks, , loadingTop] = usePromise(getTopPlayedTracks(), [], []);
+    const history = useHistory();
+
+    const handleClick = () => {
+        setDisplay(display === 'TOP' ? 'RECENT' : 'TOP');
+    };
+
+    return loadingRecent || loadingTop ? (
+        <Loading />
+    ) : (
+            <div className="user-page-section__container border container shadow-sm">
+                <section className="user-page-section">
+                    <TracksSectionTop currentTab={display} onClick={handleClick} />
+                    {display === 'TOP' &&
+                        <TrackCarousel history={history} tracks={topTracks} />}
+                    {display === 'RECENT' &&
+                        <RecentTracksCarousel history={history} tracks={recentTracks} />}
+                </section>
+            </div>
+        );
 };
-
-const UserTracksSection = ({
-    display, history, onClick, tracks,
-}: Props) => (
-    <div className="user-page-section__container border container shadow-sm">
-        <section className="user-page-section">
-            <TracksSectionTop currentTab={display} onClick={onClick} />
-            {display === 'TOP' &&
-                <TrackCarousel history={history} tracks={tracks} />}
-            {display === 'RECENT' &&
-                <RecentTracksCarousel history={history} tracks={tracks} />}
-        </section>
-    </div>
-);
 
 type TracksSectionTopProps = {
     currentTab: string,
@@ -43,8 +53,8 @@ const TracksSectionTop = ({ currentTab, onClick }: TracksSectionTopProps) => (
         </div>
         <div className="col-auto tracks-section-switch">
             <button
-              className="btn tracks-section-switch__button"
-              onClick={onClick}
+                className="btn tracks-section-switch__button"
+                onClick={onClick}
             >
                 <i className="fas fa-exchange-alt" />
             </button>

--- a/musicritic/src/components/search/SearchResultsPage.js
+++ b/musicritic/src/components/search/SearchResultsPage.js
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 
 import SearchResult from './SearchResult';
 import SearchResultsNav from './SearchResultsNav';
+import Loading from '../common/loading/Loading';
 import { search } from '../../api/SpotifyWebAPI';
 import { usePromise } from '../../utils/hooks';
 
@@ -15,7 +16,7 @@ const SearchResultsPage = () => {
     return (
         <div>
             <SearchResultsNav query={query} />
-            {loading && !error ? null : <SearchResult results={results} />}
+            {loading ? <Loading /> : !error ? <SearchResult results={results} /> : null}
         </div>
     );
 };

--- a/musicritic/src/components/search/SearchResultsPage.js
+++ b/musicritic/src/components/search/SearchResultsPage.js
@@ -11,12 +11,12 @@ import { usePromise } from '../../utils/hooks';
 
 const SearchResultsPage = () => {
     const { query } = useParams();
-    const [results, error, loading] = usePromise(search(query), {}, [query]);
+    const [results,, loading] = usePromise(search(query), {}, [query]);
 
     return (
         <div>
             <SearchResultsNav query={query} />
-            {loading ? <Loading /> : !error ? <SearchResult results={results} /> : null}
+            {loading ? <Loading /> : <SearchResult results={results} />}
         </div>
     );
 };

--- a/musicritic/src/components/track/TrackPage.js
+++ b/musicritic/src/components/track/TrackPage.js
@@ -11,6 +11,7 @@ import TrackPageSidebar from './TrackPageSidebar';
 
 import './TrackPage.css';
 import ReviewSection from '../review/ReviewSection';
+import Loading from '../common/loading/Loading';
 import {
     getTrackReviews,
     getCurrentUserTrackReview,
@@ -78,7 +79,7 @@ const TrackPage = () => {
                 <ReviewSection trackId={id} reviews={reviews} />
             </div>
         </div>
-    ) : null;
+    ) : <Loading />;
 };
 
 export default TrackPage;

--- a/musicritic/src/components/track/review/TrackReviewPage.js
+++ b/musicritic/src/components/track/review/TrackReviewPage.js
@@ -7,6 +7,7 @@ import { postTrackReview, updateTrackReview, getCurrentUserTrackReview } from '.
 
 import Rating from '../../common/rating/Rating';
 import CustomPalette from '../../common/palette/CustomPalette';
+import Loading from '../../common/loading/Loading';
 
 import './TrackReviewPage.css';
 
@@ -47,7 +48,7 @@ const TrackReviewPage = () => {
     history.push(`/track/${id}`);
   }
 
-  return !loading && (
+  return !loading ? (
     <>
       <TrackReviewPageHeader track={track} />
       <div className="album-page container">
@@ -57,7 +58,7 @@ const TrackReviewPage = () => {
         <ReviewButtonBar handleSubmit={handleSubmit} handleCancel={handleCancel} />
       </div>
     </>
-  );
+  ) : <Loading />;
 }
 
 type RatingProps = {


### PR DESCRIPTION
#### Features
- Add a loading state to pages which involve asynchronous requests (Resolves #98);
- Fix empty home page at first load (Resolves #45);
- Fix incorrect order of elements in Carousel (Resolves #49).  

#### Screenshots
![image](https://user-images.githubusercontent.com/20714148/98021239-d9debe00-1de2-11eb-8549-0286e55efdc9.png)