### PR TITLE
Add creation and update dates for reviews

### DIFF
--- a/musicritic/src/api/TrackAPI.js
+++ b/musicritic/src/api/TrackAPI.js
@@ -2,54 +2,62 @@
 
 import axios from 'axios';
 
+type ReviewInfoModel = {
+    createdAt: Date | null,
+    updatedAt: Date | null,
+    content: string,
+};
+
 export const trackApi = axios.create({
-  baseURL: process.env.SERVER_BASE_URL,
-  headers: {
-    Authorization: localStorage.getItem('authToken')
-  }
+    baseURL: process.env.SERVER_BASE_URL,
+    headers: {
+        Authorization: localStorage.getItem('authToken'),
+    },
 });
 
 export const postTrackReview = (
-  trackID: string,
-  rating: number,
-  review?: string
-) => (
-    trackApi.post(`track/${trackID}/reviews`, { rating, review })
-      .then(result => result.data)
-      .catch((error) => {
-        throw error.response.data;
-      })
-  );
+    trackID: string,
+    rating: number,
+    review?: ReviewInfoModel
+) =>
+    trackApi
+        .post(
+            `track/${trackID}/reviews`,
+            review ? { rating, review } : { rating }
+        )
+        .then(result => result.data)
+        .catch(error => {
+            throw error.response.data;
+        });
 
 export const updateTrackReview = (
-  trackID: string,
-  reviewId: string,
-  rating: number,
-  review?: string
-) => (
-    trackApi.put(`track/${trackID}/reviews/${reviewId}`, { rating, review })
-      .then(result => result.data)
-      .catch((error) => {
-        throw error.response.data;
-      })
-  );
+    trackID: string,
+    reviewId: string,
+    rating: number,
+    review?: ReviewInfoModel
+) =>
+    trackApi
+        .put(
+            `track/${trackID}/reviews/${reviewId}`,
+            review ? { rating, review } : { rating }
+        )
+        .then(result => result.data)
+        .catch(error => {
+            throw error.response.data;
+        });
 
-export const getCurrentUserTrackReview = (
-  trackID: string,
-) => (
-    trackApi.get(`track/${trackID}/reviews/me`)
-      .then(result => result.data)
-      .catch((error) => {
-        throw error.response.data;
-      })
-  );
+export const getCurrentUserTrackReview = (trackID: string) =>
+    trackApi
+        .get(`track/${trackID}/reviews/me`)
+        .then(result => result.data)
+        .catch(error => {
+            throw error.response.data;
+        });
 
-export const getTrackReviews = (
-  trackID: string,
-) => (
-    trackApi.get(`track/${trackID}/reviews`)
-      .then(result => result.data)
-      .catch((error) => {
-        throw error.response.data;
-      })
-  );
+export const getTrackReviews = (trackID: string) =>
+    trackApi
+        .get(`track/${trackID}/reviews`)
+        .then(result => result.data)
+        .catch(error => {
+            throw error.response.data;
+        });

--- a/musicritic/src/components/review/ReviewSection.js
+++ b/musicritic/src/components/review/ReviewSection.js
@@ -77,7 +77,7 @@ type Author = {
     displayName: string,
     avatarUrl: string,
     authorUid: string,
-}
+};
 
 type ReviewCardProps = {
     rating: number,
@@ -89,11 +89,7 @@ type ReviewCardProps = {
     },
 };
 
-const ReviewCard = ({
-    rating,
-    review,
-    author,
-}: ReviewCardProps) => {
+const ReviewCard = ({ rating, review, author }: ReviewCardProps) => {
     const isLongReview = review.content.length > 500;
     const reviewDate = review ? formatDate(review.updatedAt) : null;
 
@@ -120,8 +116,8 @@ const ReviewCard = ({
                         alt={`${author.displayName}`}
                     />
                     <span className="review-user-name">
-                        <span className="bold-text">{author.displayName}</span> &apos;s
-                        review
+                        <span className="bold-text">{author.displayName}</span>{' '}
+                        &apos;s review
                     </span>
                 </div>
                 <span className="review-rating">

--- a/musicritic/src/components/review/ReviewSection.js
+++ b/musicritic/src/components/review/ReviewSection.js
@@ -31,9 +31,21 @@ const formatDate = (date: string) => {
     return `${month} ${d.getDate()}${daySuffix}, ${d.getFullYear()}`;
 };
 
+type Review = {
+    id: string,
+    authorUid: string,
+    trackId: string,
+    rating: number,
+    review?: {
+        createdAt: Date,
+        updatedAt: Date,
+        content: string,
+    },
+};
+
 type ReviewSectionProps = {
     trackId: string,
-    reviews: Object,
+    reviews: Array<Review>,
 };
 
 const ReviewSection = ({ trackId, reviews }: ReviewSectionProps) => (
@@ -42,16 +54,18 @@ const ReviewSection = ({ trackId, reviews }: ReviewSectionProps) => (
             <ComposeReviewButton trackId={trackId} />
         </SectionHeader>
         <div className="reviews-wrapper">
-            {reviews.map(review => (
-                <ReviewCard key={review.id} {...review} />
-            ))}
+            {reviews
+                .filter(review => review.review)
+                .map(review => (
+                    <ReviewCard key={review.id} {...review} />
+                ))}
         </div>
     </div>
 );
 
 type ComposeReviewButtonProps = {
-    trackId: string
-}
+    trackId: string,
+};
 
 const ComposeReviewButton = ({ trackId }: ComposeReviewButtonProps) => (
     <a href={`/track/${trackId}/review`} className="compose-review-button">
@@ -67,33 +81,33 @@ type Author = {
 
 type ReviewCardProps = {
     rating: number,
-    review: string,
-    date: string,
     author: Author,
+    review: {
+        createdAt: Date,
+        updatedAt: Date,
+        content: string,
+    },
 };
 
 const ReviewCard = ({
     rating,
     review,
-    date,
     author,
 }: ReviewCardProps) => {
-    if (!review) return null;
-
-    const isLongReview = review.length > 500;
-    const reviewDate = formatDate(date);
+    const isLongReview = review.content.length > 500;
+    const reviewDate = review ? formatDate(review.updatedAt) : null;
 
     // TODO Adapt to work with HTML
     const [displayedText, setDisplayedText] = useState(
-        isLongReview ? `${review.substring(0, 497)}...` : review
+        isLongReview ? `${review.content.substring(0, 497)}...` : review.content
     );
 
     const onShowMore = () => {
-        setDisplayedText(review);
+        setDisplayedText(review.content);
     };
 
     const onShowLess = () => {
-        setDisplayedText(`${review.substring(0, 247)}...`);
+        setDisplayedText(`${review.content.substring(0, 247)}...`);
     };
 
     return (
@@ -115,13 +129,16 @@ const ReviewCard = ({
                 </span>
             </div>
             <div className="review-text-area">
-                <span dangerouslySetInnerHTML={{ __html: review }} className="review-text" />
-                {isLongReview && displayedText !== review && (
+                <span
+                    dangerouslySetInnerHTML={{ __html: review.content }}
+                    className="review-text"
+                />
+                {isLongReview && displayedText !== review.content && (
                     <button className="change-text-button" onClick={onShowMore}>
                         Show More
                     </button>
                 )}
-                {isLongReview && displayedText === review && (
+                {isLongReview && displayedText === review.content && (
                     <button className="change-text-button" onClick={onShowLess}>
                         Show Less
                     </button>

--- a/musicritic/src/components/review/ReviewSection.js
+++ b/musicritic/src/components/review/ReviewSection.js
@@ -6,7 +6,7 @@ import SectionHeader from '../common/section-header/SectionHeader';
 
 import './ReviewSection.css';
 
-const formatDate = (date: string) => {
+const formatDate = (date: Date) => {
     const daySuffixes = ['th', 'st', 'nd', 'rd'];
     const monthNames = [
         'January',
@@ -31,9 +31,15 @@ const formatDate = (date: string) => {
     return `${month} ${d.getDate()}${daySuffix}, ${d.getFullYear()}`;
 };
 
+type Author = {
+    displayName: string,
+    avatarUrl: string,
+    authorUid: string,
+};
+
 type Review = {
     id: string,
-    authorUid: string,
+    author: Author,
     trackId: string,
     rating: number,
     review?: {
@@ -72,12 +78,6 @@ const ComposeReviewButton = ({ trackId }: ComposeReviewButtonProps) => (
         Compose Review
     </a>
 );
-
-type Author = {
-    displayName: string,
-    avatarUrl: string,
-    authorUid: string,
-};
 
 type ReviewCardProps = {
     rating: number,

--- a/musicritic/src/components/track/TrackPage.js
+++ b/musicritic/src/components/track/TrackPage.js
@@ -15,7 +15,7 @@ import Loading from '../common/loading/Loading';
 import {
     getTrackReviews,
     getCurrentUserTrackReview,
-    postTrackReview
+    postTrackReview,
 } from '../../api/TrackAPI';
 
 const TrackPage = () => {
@@ -46,7 +46,9 @@ const TrackPage = () => {
                 trackNumber
             );
             const reviewsResponse = await getTrackReviews(id);
-            const { rating: ratingResponse } = await getCurrentUserTrackReview(id);
+            const { rating: ratingResponse } = await getCurrentUserTrackReview(
+                id
+            );
 
             setTrack(trackResponse);
             setRating(ratingResponse);
@@ -59,9 +61,9 @@ const TrackPage = () => {
         getTrackFromAPI();
     }, [id]);
 
-    const postRating = (newRating: number) => { 
+    const postRating = (newRating: number) => {
         if (newRating !== rating) postTrackReview(id, newRating);
-    }
+    };
 
     // TODO Use actual values
     return !loading ? (
@@ -79,7 +81,9 @@ const TrackPage = () => {
                 <ReviewSection trackId={id} reviews={reviews} />
             </div>
         </div>
-    ) : <Loading />;
+    ) : (
+        <Loading />
+    );
 };
 
 export default TrackPage;

--- a/musicritic/src/components/track/TrackPageSidebar.js
+++ b/musicritic/src/components/track/TrackPageSidebar.js
@@ -12,12 +12,17 @@ type Props = {
     nextTrack: Track | {},
 };
 
-const TrackPageSidebar = ({ userRating, postRating, track, prevTrack, nextTrack }: Props) => (
+const TrackPageSidebar = ({
+    userRating,
+    postRating,
+    track,
+    prevTrack,
+    nextTrack,
+}: Props) => (
     <div>
         <div
-          className="album-summary text-light"
-          style={{ backgroundImage: `url(${track.album.imageUrl})` }}
-        >
+            className="album-summary text-light"
+            style={{ backgroundImage: `url(${track.album.imageUrl})` }}>
             <div className="track-page-header__data">
                 <img
                     alt="Album"
@@ -26,31 +31,43 @@ const TrackPageSidebar = ({ userRating, postRating, track, prevTrack, nextTrack 
                 />
                 <TrackInfo track={track} />
             </div>
-            <TrackRatings averageRating={3.5} userRating={userRating} postRating={postRating} />
+            <TrackRatings
+                averageRating={3.5}
+                userRating={userRating}
+                postRating={postRating}
+            />
             <div className="album-menu">
                 <button
-                  type="button"
-                  className="btn album-menu__button album-menu__button--play text-light"
-                >
+                    type="button"
+                    className="btn album-menu__button album-menu__button--play text-light">
                     Open on Spotify
                 </button>
             </div>
         </div>
         {(prevTrack.name || nextTrack.name) && (
-            <TrackAlbumNavigation track={track} prevTrack={prevTrack} nextTrack={nextTrack} />
+            <TrackAlbumNavigation
+                track={track}
+                prevTrack={prevTrack}
+                nextTrack={nextTrack}
+            />
         )}
     </div>
 );
 
 type TrackInfoProps = {
     track: Track,
-}
+};
 
 const TrackInfo = ({ track }: TrackInfoProps) => (
     <div className="text-center track-info">
         <h1>{track.name}</h1>
         <h4>by {track.stringArtists}</h4>
-        <h5>from the album <a className="text-light" href={`/album/${track.album.id}/`}>{track.albumName}</a></h5>
+        <h5>
+            from the album{' '}
+            <a className="text-light" href={`/album/${track.album.id}/`}>
+                {track.albumName}
+            </a>
+        </h5>
         <p>
             {track.releaseYear} &bull; {track.length}
         </p>
@@ -59,27 +76,35 @@ const TrackInfo = ({ track }: TrackInfoProps) => (
 
 const TrackAlbumNavigation = ({ track, prevTrack, nextTrack }: Props) => {
     const history = useHistory();
-    const clickableProps = (trackId) => ({
+    const clickableProps = trackId => ({
         onClick: () => history.push(`/track/${trackId}/`),
         tabIndex: 0,
         onKeyPress: () => {},
         role: 'button',
     });
-    
+
     return (
         <div className="track-album-navigation text-center text-light">
             <h5 className="mb-3">
-                More from <a className="text-light" href={`/album/${track.album.id}/`}>{track.albumName}</a>:
+                More from{' '}
+                <a className="text-light" href={`/album/${track.album.id}/`}>
+                    {track.albumName}
+                </a>
+                :
             </h5>
             <div className="track-album-navigation-container row">
                 {prevTrack.name && (
-                    <div {...clickableProps(prevTrack.id)} className="track-album-navigation-button col-4">
+                    <div
+                        {...clickableProps(prevTrack.id)}
+                        className="track-album-navigation-button col-4">
                         <p className="album-rating__title">{'<'} Previous</p>
                         <p className="mb-0">{prevTrack.name}</p>
                     </div>
                 )}
                 {nextTrack.name && (
-                    <div {...clickableProps(nextTrack.id)} className="track-album-navigation-button col-4">
+                    <div
+                        {...clickableProps(nextTrack.id)}
+                        className="track-album-navigation-button col-4">
                         <p className="album-rating__title">Next {'>'}</p>
                         <p className="mb-0">{nextTrack.name}</p>
                     </div>
@@ -95,16 +120,20 @@ type TrackRatingsProps = {
     userRating: number,
 };
 
-const TrackRatings =({ averageRating, userRating, postRating }: TrackRatingsProps) => (
+const TrackRatings = ({
+    averageRating,
+    userRating,
+    postRating,
+}: TrackRatingsProps) => (
     <div className="album-ratings row">
         <TrackRating
             rating={averageRating}
             title="Average rating"
             displayOnly
         />
-        <TrackRating 
+        <TrackRating
             rating={userRating}
-            title="Your rating" 
+            title="Your rating"
             postRating={postRating}
         />
     </div>
@@ -114,14 +143,14 @@ type TrackRatingProps = {
     rating: number,
     title: string,
     displayOnly?: boolean,
-    postRating?: Function
+    postRating?: Function,
 };
 
-const TrackRating = ({ 
+const TrackRating = ({
     rating,
     title,
     displayOnly,
-    postRating
+    postRating,
 }: TrackRatingProps) => (
     <div className="album-rating col-4">
         <p className="album-rating__title">{title}</p>

--- a/musicritic/src/components/track/review/TrackReviewPage.js
+++ b/musicritic/src/components/track/review/TrackReviewPage.js
@@ -32,7 +32,6 @@ const TrackReviewPage = () => {
         async function getTrackFromAPI() {
             const trackResponse = await getTrack(id);
             const reviewResponse = await getCurrentUserTrackReview(id);
-            console.log(reviewResponse);
             setTrack(trackResponse);
             setReviewId(reviewResponse.id);
             setRating(reviewResponse.rating);
@@ -65,7 +64,7 @@ const TrackReviewPage = () => {
             <div className="album-page container">
                 <h4>What did you think about this track?</h4>
                 <ComposeReviewTextArea
-                    review={review.review}
+                    review={review}
                     setReview={setReview}
                 />
                 <TrackReviewRating rating={rating} setRating={setRating} />

--- a/musicritic/src/components/track/review/TrackReviewPage.js
+++ b/musicritic/src/components/track/review/TrackReviewPage.js
@@ -3,7 +3,11 @@ import { useParams, useHistory } from 'react-router-dom';
 import MediumEditor from 'medium-editor';
 import { getTrack, Track } from 'spotify-web-sdk';
 
-import { postTrackReview, updateTrackReview, getCurrentUserTrackReview } from '../../../api/TrackAPI';
+import {
+    postTrackReview,
+    updateTrackReview,
+    getCurrentUserTrackReview,
+} from '../../../api/TrackAPI';
 
 import Rating from '../../common/rating/Rating';
 import CustomPalette from '../../common/palette/CustomPalette';
@@ -12,127 +16,152 @@ import Loading from '../../common/loading/Loading';
 import './TrackReviewPage.css';
 
 const TrackReviewPage = () => {
-  const [track, setTrack] = useState({});
-  const [loading, setLoading] = useState(true);
-  const [review, setReview] = useState('');
-  const [rating, setRating] = useState(0);
-  const [reviewId, setReviewId] = useState('');
-  const history = useHistory();
-  const { id } = useParams();
+    const [track, setTrack] = useState({});
+    const [loading, setLoading] = useState(true);
+    const [review, setReview] = useState({
+        createdAt: null,
+        updatedAt: null,
+        content: '',
+    });
+    const [rating, setRating] = useState(0);
+    const [reviewId, setReviewId] = useState('');
+    const history = useHistory();
+    const { id } = useParams();
 
-  useEffect(() => {
-    async function getTrackFromAPI() {
-      const trackResponse = await getTrack(id);
-      const reviewResponse = await getCurrentUserTrackReview(id);
-      setTrack(trackResponse);
-      setReviewId(reviewResponse.id);
-      setRating(reviewResponse.rating);
-      setReview(reviewResponse.review);
-      setLoading(false);
-    }
+    useEffect(() => {
+        async function getTrackFromAPI() {
+            const trackResponse = await getTrack(id);
+            const reviewResponse = await getCurrentUserTrackReview(id);
+            console.log(reviewResponse);
+            setTrack(trackResponse);
+            setReviewId(reviewResponse.id);
+            setRating(reviewResponse.rating);
+            if (reviewResponse.review) {
+                setReview(reviewResponse.review);
+            }
+            setLoading(false);
+        }
 
-    getTrackFromAPI();
-  }, [id]);
+        getTrackFromAPI();
+    }, [id]);
 
-  const handleSubmit = async () => {
-    if (reviewId && reviewId.length > 0) {
-      await updateTrackReview(id, reviewId, rating, review);
-    } else {
-      await postTrackReview(id, rating, review);
-    }
-    history.push(`/track/${id}`);
-  }
-  
-  const handleCancel = () => {
-    // TODO Open modal for confirmation
-    history.push(`/track/${id}`);
-  }
+    const handleSubmit = async () => {
+        if (reviewId && reviewId.length > 0) {
+            await updateTrackReview(id, reviewId, rating, review);
+        } else {
+            await postTrackReview(id, rating, review);
+        }
+        history.push(`/track/${id}`);
+    };
 
-  return !loading ? (
-    <>
-      <TrackReviewPageHeader track={track} />
-      <div className="album-page container">
-        <h4>What did you think about this track?</h4>
-        <ComposeReviewTextArea review={review} setReview={setReview} />
-        <TrackReviewRating rating={rating} setRating={setRating} />
-        <ReviewButtonBar handleSubmit={handleSubmit} handleCancel={handleCancel} />
-      </div>
-    </>
-  ) : <Loading />;
-}
+    const handleCancel = () => {
+        // TODO Open modal for confirmation
+        history.push(`/track/${id}`);
+    };
+
+    return !loading ? (
+        <>
+            <TrackReviewPageHeader track={track} />
+            <div className="album-page container">
+                <h4>What did you think about this track?</h4>
+                <ComposeReviewTextArea
+                    review={review.review}
+                    setReview={setReview}
+                />
+                <TrackReviewRating rating={rating} setRating={setRating} />
+                <ReviewButtonBar
+                    handleSubmit={handleSubmit}
+                    handleCancel={handleCancel}
+                />
+            </div>
+        </>
+    ) : (
+        <Loading />
+    );
+};
 
 type RatingProps = {
-  rating: number,
-  setRating: (rating: number) => void,
+    rating: number,
+    setRating: (rating: number) => void,
 };
 
 const TrackReviewRating = ({ rating, setRating }: RatingProps) => (
-  <div className="d-flex">
-    <h4>Your score: </h4>
-    <h4 className="pl-2">
-      <Rating initialValue={rating} onValueChange={setRating} />
-    </h4>
-  </div>
+    <div className="d-flex">
+        <h4>Your score: </h4>
+        <h4 className="pl-2">
+            <Rating initialValue={rating} onValueChange={setRating} />
+        </h4>
+    </div>
 );
 
 type HeaderProps = {
-  track: Track,
+    track: Track,
 };
 
 const TrackReviewPageHeader = ({ track }: HeaderProps) => (
-  <CustomPalette imageUrl={track.album.imageUrl}>
-    <div className="w-100 p-5">
-      <div className="row">
-        <div className="review-page-track-info col-md-8 text-center">
-          <h2 className="font-weight-bold text-center mb-4">Write a review</h2>
-          <h2>{track.name}</h2>
-          <h3>by {track.stringArtists}</h3>
-          <h3>from the album {track.album.name}</h3>
+    <CustomPalette imageUrl={track.album.imageUrl}>
+        <div className="w-100 p-5">
+            <div className="row">
+                <div className="review-page-track-info col-md-8 text-center">
+                    <h2 className="font-weight-bold text-center mb-4">
+                        Write a review
+                    </h2>
+                    <h2>{track.name}</h2>
+                    <h3>by {track.stringArtists}</h3>
+                    <h3>from the album {track.album.name}</h3>
+                </div>
+                <div className="col-md-4 py-2">
+                    <img
+                        alt="Album"
+                        className="track-page-header__cover w-50 shadow-lg"
+                        src={track.album.imageUrl}
+                    />
+                </div>
+            </div>
         </div>
-        <div className="col-md-4 py-2">
-          <img
-            alt="Album"
-            className="track-page-header__cover w-50 shadow-lg"
-            src={track.album.imageUrl}
-          />
-        </div>
-      </div>
-    </div>
-  </CustomPalette>
+    </CustomPalette>
 );
 
 type ButtonBarProps = {
-  handleSubmit: () => void,
-  handleCancel: () => void,
-}
+    handleSubmit: () => void,
+    handleCancel: () => void,
+};
 
 const ReviewButtonBar = ({ handleSubmit, handleCancel }: ButtonBarProps) => (
-  <div className="d-flex flex-row-reverse pt-3">
-    <button onClick={handleSubmit} className="btn btn-secondary">
-      Submit Review
-    </button>
-    <button onClick={handleCancel} className="btn btn-tertiary">
-      Cancel
-    </button>
-  </div>
+    <div className="d-flex flex-row-reverse pt-3">
+        <button onClick={handleSubmit} className="btn btn-secondary">
+            Submit Review
+        </button>
+        <button onClick={handleCancel} className="btn btn-tertiary">
+            Cancel
+        </button>
+    </div>
 );
 
 type TextAreaProps = {
-  review: string,
-  setReview: (review: string) => void,
+    review: {
+        createdAt: Date | null,
+        updatedAt: Date | null,
+        content: string,
+    },
+    setReview: (review: string) => void,
 };
 
 const ComposeReviewTextArea = ({ review, setReview }: TextAreaProps) => {
-  useEffect(() => {
-    const editor = new MediumEditor('.editable');
-    editor.subscribe('editableInput', (event) => setReview(event.target.innerHTML));
-  }, []);
+    useEffect(() => {
+        const editor = new MediumEditor('.editable');
+        editor.subscribe('editableInput', event =>
+            setReview({ ...review, content: event.target.innerHTML })
+        );
+    }, []);
 
-  return (
-    <textarea initialValue={review} className="editable">
-      {review}
-    </textarea>
-  );
-}
+    return (
+        <textarea
+            initialValue={review ? review.content : ''}
+            className="editable">
+            {review ? review.content : ''}
+        </textarea>
+    );
+};
 
 export default TrackReviewPage;

--- a/server/src/track-reviews/trackReviewCollections.js
+++ b/server/src/track-reviews/trackReviewCollections.js
@@ -42,18 +42,27 @@ export const getTrackReviews = async (trackId: string) => {
     return getReviewersInformation(reviews);
 };
 
-const getReviewersInformation = async (reviews) => {
-    const usersIds = reviews.docs.map(review => ({ uid: review.data().authorUid }));
+const getReviewersInformation = async reviews => {
+    const usersIds = reviews.docs.map(review => ({
+        uid: review.data().authorUid,
+    }));
     const { users } = await auth.getUsers(usersIds);
-    return reviews.docs.map(
-        (review, i) => 
-        ({ ...review.data(), author: 
-            {
-                displayName: users[i].displayName,
-                avatarUrl: users[i].photoURL,
-                authorUid: users[i].uid,
-            } }));
-}
+
+    const reviewsData = reviews.docs.map(review => review.data());
+    return reviewsData.map((review, i) => ({
+        ...review,
+        review: review.review && {
+            createdAt: review.review.createdAt.toDate(),
+            updatedAt: review.review.updatedAt.toDate(),
+            content: review.review.content,
+        },
+        author: {
+            displayName: users[i].displayName,
+            avatarUrl: users[i].photoURL,
+            authorUid: users[i].uid,
+        },
+    }));
+};
 
 export const updateUserTrackReview = async (
     reviewId: string,

--- a/server/src/track-reviews/trackReviewCollections.js
+++ b/server/src/track-reviews/trackReviewCollections.js
@@ -89,16 +89,10 @@ export const updateUserTrackReview = async (
             message: 'Cannot change the track which is being reviewed',
         };
 
-    console.log(review);
     if (updatedTrackReview.review) {
-        if (
-            review.review &&
-            updatedTrackReview.review.createdAt !== review.review.createdAt
-        )
-            throw {
-                status: 500,
-                message: 'Cannot change the creation date of a review',
-            };
+        if (review.review)
+            updatedTrackReview.review.createdAt = review.review.createdAt;
+
         updatedTrackReview.review.updatedAt = new Date();
     }
 

--- a/server/src/track-reviews/trackReviewController.js
+++ b/server/src/track-reviews/trackReviewController.js
@@ -6,7 +6,7 @@ import {
     createTrackReview,
     getUserTrackReview,
     updateUserTrackReview,
-    getTrackReviews
+    getTrackReviews,
 } from './trackReviewCollections';
 
 const router = express.Router();
@@ -34,6 +34,11 @@ router.post('/track/:trackId/reviews', checkAuth, (req, res) => {
     const review = req.body;
     review.trackId = req.params.trackId;
     review.authorUid = req.user.uid;
+    if (review.review && !review.review.createdAt) {
+        review.review.createdAt = new Date();
+        review.review.updatedAt = review.review.createdAt;
+    }
+
     createTrackReview(review)
         .then(review => res.status(201).send(review))
         .catch(error => res.status(error.status).send(error));
@@ -42,9 +47,8 @@ router.post('/track/:trackId/reviews', checkAuth, (req, res) => {
 router.put('/track/:trackId/reviews/:reviewId', checkAuth, (req, res) => {
     const review = req.body;
     review.trackId = req.params.trackId;
-    review.id = req.params.reviewId;
     review.authorUid = req.user.uid;
-    updateUserTrackReview(review.id, review)
+    updateUserTrackReview(req.params.reviewId, review)
         .then(review => res.status(200).send(review))
         .catch(error => res.status(error.status).send(error));
 });


### PR DESCRIPTION
- **Issue:** Resolves #94 
- **Description:** Add creation and update dates to track reviews (only related to reviews's texts) on `track-reviews` collection. Also, it updates the `TrackPage` and the related components to use the collection structure and display the reviews update date.