### PR TITLE
Configure spotify requests on server side

### DIFF
--- a/musicritic/src/api/TrackAPI.js
+++ b/musicritic/src/api/TrackAPI.js
@@ -22,7 +22,7 @@ export const postTrackReview = (
 ) =>
     trackApi
         .post(
-            `track/${trackID}/reviews`,
+            `tracks/${trackID}/reviews`,
             review ? { rating, review } : { rating }
         )
         .then(result => result.data)
@@ -38,7 +38,7 @@ export const updateTrackReview = (
 ) =>
     trackApi
         .put(
-            `track/${trackID}/reviews/${reviewId}`,
+            `tracks/${trackID}/reviews/${reviewId}`,
             review ? { rating, review } : { rating }
         )
         .then(result => result.data)
@@ -48,7 +48,7 @@ export const updateTrackReview = (
 
 export const getCurrentUserTrackReview = (trackID: string) =>
     trackApi
-        .get(`track/${trackID}/reviews/me`)
+        .get(`tracks/${trackID}/reviews/me`)
         .then(result => result.data)
         .catch(error => {
             throw error.response.data;
@@ -56,7 +56,7 @@ export const getCurrentUserTrackReview = (trackID: string) =>
 
 export const getTrackReviews = (trackID: string) =>
     trackApi
-        .get(`track/${trackID}/reviews`)
+        .get(`tracks/${trackID}/reviews`)
         .then(result => result.data)
         .catch(error => {
             throw error.response.data;

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
         "lodash": "^4.17.13",
         "querystring": "^0.2.0",
         "request": "^2.88.0",
-        "spotify-web-sdk": "^0.5.2"
+        "spotify-web-sdk": "^0.7.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.0.0",

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -22,8 +22,8 @@ config.spotify = {
             user-top-read`,
     baseUri: 'https://api.spotify.com/v1',
     authBaseUri: 'https://accounts.spotify.com',
-    clientId: process.env.SPOTIFY_CLIENT_ID,
-    clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+    clientId: process.env.SPOTIFY_CLIENT_ID ?? '',
+    clientSecret: process.env.SPOTIFY_CLIENT_SECRET ?? '',
 };
 
 config.host = {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,13 +8,17 @@ import bodyParser from 'body-parser';
 import config from './config';
 import authRouter from './spotify/spotifyAuthController';
 import trackReviewsApi from './track-reviews/trackReviewController';
+import trackApi from './track/trackController';
 import checkAuth from './firebase/firebaseAuthHandler';
+import { initSpotifyToken } from './spotify/util';
 
 const app = express();
 
 app.use(bodyParser.json());
 app.use(cookieParser());
 app.use(cors());
+
+initSpotifyToken();
 
 app.use('/app', express.static('public'));
 
@@ -23,6 +27,7 @@ app.get('/hello', checkAuth, (req, res) =>
 );
 
 app.use(authRouter);
+app.use(trackApi);
 app.use(trackReviewsApi);
 
 const server = http.createServer(app);

--- a/server/src/spotify/util.js
+++ b/server/src/spotify/util.js
@@ -2,6 +2,33 @@
 
 import config from '../config';
 import axios from 'axios';
+import * as spotify from 'spotify-web-sdk';
+import * as qs from 'querystring';
+
+export const spotifySdk = spotify;
+
+export const initSpotifyToken = () => {
+    const authorization = `${config.spotify.clientId}:${config.spotify.clientSecret}`;
+    const buff = new Buffer(authorization);
+    spotify.init({
+        token: 'token',
+        refreshTokenFunction: async () => {
+            const { data } = await axios.post(
+                `${config.spotify.authBaseUri}/api/token`,
+                qs.stringify({
+                    grant_type: 'client_credentials',
+                }),
+                {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        Authorization: `Basic ${buff.toString('base64')}`,
+                    },
+                }
+            );
+            return data.access_token;
+        },
+    });
+};
 
 export const generateRandomState = (length: number) => {
     let state = '';

--- a/server/src/track-reviews/trackReviewController.js
+++ b/server/src/track-reviews/trackReviewController.js
@@ -11,14 +11,14 @@ import {
 
 const router = express.Router();
 
-router.get('/track/:trackId/reviews', (req, res) => {
+router.get('/tracks/:trackId/reviews', (req, res) => {
     const trackId = req.params.trackId;
     getTrackReviews(trackId)
         .then(reviews => res.status(200).send(reviews))
         .catch(error => res.status(error.status).send(error));
 });
 
-router.get('/track/:trackId/reviews/me', checkAuth, (req, res) => {
+router.get('/tracks/:trackId/reviews/me', checkAuth, (req, res) => {
     const trackId = req.params.trackId;
     const authorUid = req.user.uid;
     getUserTrackReview(trackId, authorUid)
@@ -30,7 +30,7 @@ router.get('/track/:trackId/reviews/me', checkAuth, (req, res) => {
         .catch(error => res.status(error.status).send(error));
 });
 
-router.post('/track/:trackId/reviews', checkAuth, (req, res) => {
+router.post('/tracks/:trackId/reviews', checkAuth, (req, res) => {
     const review = req.body;
     review.trackId = req.params.trackId;
     review.authorUid = req.user.uid;
@@ -44,7 +44,7 @@ router.post('/track/:trackId/reviews', checkAuth, (req, res) => {
         .catch(error => res.status(error.status).send(error));
 });
 
-router.put('/track/:trackId/reviews/:reviewId', checkAuth, (req, res) => {
+router.put('/tracks/:trackId/reviews/:reviewId', checkAuth, (req, res) => {
     const review = req.body;
     review.trackId = req.params.trackId;
     review.authorUid = req.user.uid;

--- a/server/src/track/trackController.js
+++ b/server/src/track/trackController.js
@@ -1,0 +1,12 @@
+/* @flow */
+import express from 'express';
+import { spotifySdk } from '../spotify/util';
+
+const router = express.Router();
+
+router.get('/tracks/:id', async (req, res) => {
+    const track = await spotifySdk.getTrack(req.params.id);
+    res.status(200).send(track);
+});
+
+export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7495,6 +7495,11 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.differenceby@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/lodash.differenceby/-/lodash.differenceby-4.8.0.tgz#cfd59e94353af5de51da5d302ca4ebff33faac57"
+  integrity sha1-z9WelDU69d5R2l0wLKTr/zP6rFc=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -7504,6 +7509,11 @@ lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
   integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.intersectionby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.intersectionby/-/lodash.intersectionby-4.7.0.tgz#12f125e4da00b22290febda1b6c1b68bb9255125"
+  integrity sha1-EvEl5NoAsiKQ/r2htsG2i7klUSU=
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -7550,20 +7560,40 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
+lodash.keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+  integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -10786,7 +10816,7 @@ split@^1.0.0:
   dependencies:
     through "2"
 
-spotify-web-sdk@^0.5.0, spotify-web-sdk@^0.5.2:
+spotify-web-sdk@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/spotify-web-sdk/-/spotify-web-sdk-0.5.2.tgz#ae0914025239c7af89d4820c2acbf92a7f87d2e9"
   integrity sha512-dLyWj8cbRZSjZAR6KGyxYWeotoFjYImom7h5CoMboLjKw0/Vv/H7KJQia7kBhvPfgBdKlPRPBlgiu07wEeF0jg==
@@ -10794,6 +10824,19 @@ spotify-web-sdk@^0.5.0, spotify-web-sdk@^0.5.2:
     "@types/lodash" "^4.14.121"
     axios "^0.18.1"
     lodash "^4.17.13"
+
+spotify-web-sdk@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/spotify-web-sdk/-/spotify-web-sdk-0.7.0.tgz#ef3926e920199b8bc39029206d4e4e9a509a54cb"
+  integrity sha512-t13jWeBitHTsbYisUKBmSuZHEhN1F3IZ1i/FYYNHTGmSZOIgW0Okq30AGXgYQXML8/7Wg4YeH/U+3hZtn09zHw==
+  dependencies:
+    axios "^0.18.1"
+    lodash.differenceby "^4.8.0"
+    lodash.intersectionby "^4.7.0"
+    lodash.keys "^4.2.0"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    lodash.snakecase "^4.1.1"
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This PR resolves #103 

With this PR is now possible to make Spotify requests on the server-side without needing a Spotify token from the user, for making not user-based requests like retrieving tracks, albums, artists, and searching.

To test this PR you can check the sample endpoint I've created (GET /tracks/:trackId) and it will return a JSON with a song from Spotify with the given ID


PS: I also renamed the endpoints `/track` to `/tracks`