### PR TITLE
Add average rating for tracks and albums

### DIFF
--- a/musicritic/src/api/TrackAPI.js
+++ b/musicritic/src/api/TrackAPI.js
@@ -61,3 +61,11 @@ export const getTrackReviews = (trackID: string) =>
         .catch(error => {
             throw error.response.data;
         });
+
+export const getTrackAverageRating = (trackID: string) =>
+    trackApi
+        .get(`tracks/${trackID}`)
+        .then(result => result.data.averageRating)
+        .catch(error => {
+            throw error.response.data;
+        });

--- a/musicritic/src/components/track/TrackPage.js
+++ b/musicritic/src/components/track/TrackPage.js
@@ -51,11 +51,11 @@ const TrackPage = () => {
             const { rating: ratingResponse } = await getCurrentUserTrackReview(
                 id
             );
-            const averageRating = await getTrackAverageRating(id);
+            const avgRatingResponse = await getTrackAverageRating(id);
 
             setTrack(trackResponse);
             setRating(ratingResponse);
-            setAverageRating(averageRating);
+            setAverageRating(avgRatingResponse);
             setPrevTrack(prevTrackResponse);
             setNextTrack(nextTrackResponse);
             setReviews(reviewsResponse);

--- a/musicritic/src/components/track/TrackPage.js
+++ b/musicritic/src/components/track/TrackPage.js
@@ -14,6 +14,7 @@ import ReviewSection from '../review/ReviewSection';
 import Loading from '../common/loading/Loading';
 import {
     getTrackReviews,
+    getTrackAverageRating,
     getCurrentUserTrackReview,
     postTrackReview,
 } from '../../api/TrackAPI';
@@ -21,6 +22,7 @@ import {
 const TrackPage = () => {
     const [loading, setLoading] = useState(true);
     const [rating, setRating] = useState(0);
+    const [averageRating, setAverageRating] = useState(0);
     const [track, setTrack] = useState({});
     const [reviews, setReviews] = useState([]);
     const [prevTrack, setPrevTrack] = useState({});
@@ -49,9 +51,11 @@ const TrackPage = () => {
             const { rating: ratingResponse } = await getCurrentUserTrackReview(
                 id
             );
+            const averageRating = await getTrackAverageRating(id);
 
             setTrack(trackResponse);
             setRating(ratingResponse);
+            setAverageRating(averageRating);
             setPrevTrack(prevTrackResponse);
             setNextTrack(nextTrackResponse);
             setReviews(reviewsResponse);
@@ -60,6 +64,15 @@ const TrackPage = () => {
 
         getTrackFromAPI();
     }, [id]);
+
+    useEffect(() => {
+        const updateAverageRating = async () => {
+            const newAverageRating = await getTrackAverageRating(id);
+            setAverageRating(newAverageRating);
+        };
+
+        updateAverageRating();
+    }, [rating]);
 
     const postRating = (newRating: number) => {
         if (newRating !== rating) postTrackReview(id, newRating);
@@ -71,6 +84,7 @@ const TrackPage = () => {
             <div className="col-lg-4">
                 <TrackPageSidebar
                     userRating={rating}
+                    averageRating={averageRating}
                     postRating={postRating}
                     track={track}
                     prevTrack={prevTrack}

--- a/musicritic/src/components/track/TrackPageSidebar.js
+++ b/musicritic/src/components/track/TrackPageSidebar.js
@@ -6,6 +6,7 @@ import Rating from '../common/rating/Rating';
 
 type Props = {
     userRating: number,
+    averageRating: number,
     postRating: (rating: number) => void,
     track: Track,
     prevTrack: Track | {},
@@ -14,6 +15,7 @@ type Props = {
 
 const TrackPageSidebar = ({
     userRating,
+    averageRating,
     postRating,
     track,
     prevTrack,
@@ -32,7 +34,7 @@ const TrackPageSidebar = ({
                 <TrackInfo track={track} />
             </div>
             <TrackRatings
-                averageRating={3.5}
+                averageRating={averageRating}
                 userRating={userRating}
                 postRating={postRating}
             />

--- a/server/src/album/albumController.js
+++ b/server/src/album/albumController.js
@@ -1,0 +1,25 @@
+/* @flow */
+import express from 'express';
+import { spotifySdk } from '../spotify/util';
+
+import { ALBUM } from '../reviews/albumReviewController';
+import { getReviews } from '../reviews/reviewCollections';
+
+const router = express.Router();
+
+router.get('/albums/:id', async (req, res) => {
+    const albumId = req.params.id;
+
+    const album = await spotifySdk.getAlbum(albumId);
+    const albumReviews = await getReviews(albumId, ALBUM);
+
+    const albumRatings = albumReviews.map(review => review.rating);
+    const averageRating =
+        albumRatings.length > 0
+            ? albumRatings.reduce((x, y) => x + y) / albumRatings.length
+            : 0;
+
+    res.status(200).send({ album, averageRating });
+});
+
+export default router;

--- a/server/src/track/trackController.js
+++ b/server/src/track/trackController.js
@@ -2,11 +2,24 @@
 import express from 'express';
 import { spotifySdk } from '../spotify/util';
 
+import { TRACK } from '../reviews/trackReviewController';
+import { getReviews } from '../reviews/reviewCollections';
+
 const router = express.Router();
 
 router.get('/tracks/:id', async (req, res) => {
-    const track = await spotifySdk.getTrack(req.params.id);
-    res.status(200).send(track);
+    const trackId = req.params.id;
+
+    const track = await spotifySdk.getTrack(trackId);
+    const trackReviews = await getReviews(trackId, TRACK);
+
+    const trackRatings = trackReviews.map(review => review.rating);
+    const averageRating =
+        trackRatings.length > 0
+            ? trackRatings.reduce((x, y) => x + y) / trackRatings.length
+            : 0;
+
+    res.status(200).send({ track, averageRating });
 });
 
 export default router;


### PR DESCRIPTION
- **Issue:** Resolves #105 
- **Description:** As requested on issue, this PR adds average ratings for reviews of tracks and albums. These ratings can be accessed on routes `tracks/:id` and `albums/:id` in the `averageRating` field. The `TrackPage` is already displaying the average rating and the `AlbumPage` will be able to use it with very similar implementation.