### PR TITLE
Fix review POSTs not storing content

### DIFF
--- a/server/src/reviews/albumReviewController.js
+++ b/server/src/reviews/albumReviewController.js
@@ -37,7 +37,7 @@ router.post('/album/:albumId/reviews', checkAuth, (req, res) => {
     review.authorUid = req.user.uid;
     review.contentType = ALBUM;
     if (!review.review || !review.review.createdAt) {
-        review.review = {};
+        review.review = review.review || {};
         review.review.createdAt = new Date();
         review.review.updatedAt = review.review.createdAt;
     }

--- a/server/src/reviews/trackReviewController.js
+++ b/server/src/reviews/trackReviewController.js
@@ -37,11 +37,10 @@ router.post('/tracks/:trackId/reviews', checkAuth, (req, res) => {
     review.authorUid = req.user.uid;
     review.contentType = TRACK;
     if (!review.review || !review.review.createdAt) {
-        review.review = {};
+        review.review = review.review || {};
         review.review.createdAt = new Date();
         review.review.updatedAt = review.review.createdAt;
     }
-
     createReview(review)
         .then(review => res.status(201).send(review))
         .catch(error => res.status(error.status).send(error));


### PR DESCRIPTION
This PR addresses the problem of POSTs not storing content. This was caused by clearing the `review` attribute before adding dates, which caused the `content` attribute to be lost.