### PR TITLE
Add component to create protected routes

### DIFF
--- a/musicritic/src/components/app/App.js
+++ b/musicritic/src/components/app/App.js
@@ -9,8 +9,8 @@ import Navbar from './Navbar';
 import MainContent from './MainContent';
 import auth from '../../firebase/firebase-config';
 
-const useCurrentUser = () => {
-    const [user, setUser] = useState(auth.currentUser);
+export const useCurrentUser = () => {
+    const [user, setUser] = useState('unknown');
     useEffect(() => {
         const unsubscribe = auth.onAuthStateChanged(u => {
             if (u) {

--- a/musicritic/src/components/app/MainContent.js
+++ b/musicritic/src/components/app/MainContent.js
@@ -36,20 +36,20 @@ const MainContent = () => (
             path="/auth/:token/:refresh/:musicritic"
             component={Auth}
         />
-        <ProtectedRoute>
-            <Route exact path="/album/:id/(reviews|)" component={AlbumPage} />
+        <ProtectedRoute exact path="/album/:id/(reviews|)">
+            <AlbumPage />
         </ProtectedRoute>
-        <ProtectedRoute>
-            <Route exact path="/track/:id" component={TrackPage} />
+        <ProtectedRoute exact path="/track/:id">
+            <TrackPage />
         </ProtectedRoute>
-        <ProtectedRoute>
-            <Route exact path="/track/:id/review" component={TrackReviewPage} />
+        <ProtectedRoute exact path="/track/:id/review">
+            <TrackReviewPage />
         </ProtectedRoute>
-        <ProtectedRoute>
-            <Route exact path="/album/:id/review" component={AlbumReviewPage} />
+        <ProtectedRoute exact path="/album/:id/review">
+            <AlbumReviewPage />
         </ProtectedRoute>
-        <ProtectedRoute>
-            <Route exact path="/artist/:id" component={ArtistPage} />
+        <ProtectedRoute exact path="/artist/:id/">
+            <ArtistPage />
         </ProtectedRoute>
     </Switch>
 );

--- a/musicritic/src/components/app/MainContent.js
+++ b/musicritic/src/components/app/MainContent.js
@@ -36,7 +36,7 @@ const MainContent = () => (
             path="/auth/:token/:refresh/:musicritic"
             component={Auth}
         />
-        <ProtectedRoute exact path="/album/:id/(reviews|)">
+        <ProtectedRoute exact path="/album/:id">
             <AlbumPage />
         </ProtectedRoute>
         <ProtectedRoute exact path="/track/:id">
@@ -48,7 +48,7 @@ const MainContent = () => (
         <ProtectedRoute exact path="/album/:id/review">
             <AlbumReviewPage />
         </ProtectedRoute>
-        <ProtectedRoute exact path="/artist/:id/">
+        <ProtectedRoute exact path="/artist/:id">
             <ArtistPage />
         </ProtectedRoute>
     </Switch>

--- a/musicritic/src/components/app/MainContent.js
+++ b/musicritic/src/components/app/MainContent.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import ContainerizedRoute from './routes/ContainerizedRoute';
+import ProtectedRoute from './routes/ProtectedRoute';
 
 import UserPage from '../profile/UserPage';
 import Auth from '../login/Auth';
@@ -35,11 +36,21 @@ const MainContent = () => (
             path="/auth/:token/:refresh/:musicritic"
             component={Auth}
         />
-        <Route exact path="/album/:id/(reviews|)" component={AlbumPage} />
-        <Route exact path="/track/:id" component={TrackPage} />
-        <Route exact path="/track/:id/review" component={TrackReviewPage} />
-        <Route exact path="/album/:id/review" component={AlbumReviewPage} />
-        <Route exact path="/artist/:id" component={ArtistPage} />
+        <ProtectedRoute>
+            <Route exact path="/album/:id/(reviews|)" component={AlbumPage} />
+        </ProtectedRoute>
+        <ProtectedRoute>
+            <Route exact path="/track/:id" component={TrackPage} />
+        </ProtectedRoute>
+        <ProtectedRoute>
+            <Route exact path="/track/:id/review" component={TrackReviewPage} />
+        </ProtectedRoute>
+        <ProtectedRoute>
+            <Route exact path="/album/:id/review" component={AlbumReviewPage} />
+        </ProtectedRoute>
+        <ProtectedRoute>
+            <Route exact path="/artist/:id" component={ArtistPage} />
+        </ProtectedRoute>
     </Switch>
 );
 

--- a/musicritic/src/components/app/routes/ProtectedRoute.css
+++ b/musicritic/src/components/app/routes/ProtectedRoute.css
@@ -1,0 +1,22 @@
+.auth-requirement {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 5rem 0;
+}
+
+.auth-requirement-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.auth-requirement-title {
+    font-weight: bold;
+    margin: 0.5rem 0;
+}
+
+.auth-requirement-text {
+    font-size: 1.3rem;
+    margin: 0 0 2rem 0;
+}

--- a/musicritic/src/components/app/routes/ProtectedRoute.js
+++ b/musicritic/src/components/app/routes/ProtectedRoute.js
@@ -1,0 +1,40 @@
+/* @flow */
+
+import React from 'react';
+import { useSession } from '../../app/App';
+
+import SocialButton from '../../common/social-button/SocialButton';
+
+import './ProtectedRoute.css';
+
+const AuthRequirement = () => {
+    const serverBaseUri = process.env.SERVER_BASE_URL || '';
+
+    return (
+        <div className="auth-requirement">
+            <div className="auth-requirement-wrapper col-sm-12 col-md-7 col-lg-5">
+                <h1 className="auth-requirement-title">
+                    Oops... You can't access this content.
+                </h1>
+                <h3 className="auth-requirement-text">
+                    Please, sign in and try again.
+                </h3>
+                <SocialButton
+                    name="spotify"
+                    url={`${serverBaseUri}/auth/login`}
+                />
+            </div>
+        </div>
+    );
+};
+
+type ProtectedRouteProps = {
+    children: any,
+};
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+    const user = useSession();
+    return user ? { ...children } : <AuthRequirement />;
+};
+
+export default ProtectedRoute;

--- a/musicritic/src/components/app/routes/ProtectedRoute.js
+++ b/musicritic/src/components/app/routes/ProtectedRoute.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import React from 'react';
+import { Route } from 'react-router-dom';
 import { useSession } from '../../app/App';
 
 import SocialButton from '../../common/social-button/SocialButton';
@@ -32,9 +33,9 @@ type ProtectedRouteProps = {
     children: any,
 };
 
-const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+const ProtectedRoute = ({ children, ...args }: ProtectedRouteProps) => {
     const user = useSession();
-    return user ? { ...children } : <AuthRequirement />;
+    return <Route {...args}>{user ? children : <AuthRequirement />}</Route>;
 };
 
 export default ProtectedRoute;

--- a/musicritic/src/components/app/routes/ProtectedRoute.js
+++ b/musicritic/src/components/app/routes/ProtectedRoute.js
@@ -2,7 +2,9 @@
 
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { useSession } from '../../app/App';
+
+import { useCurrentUser } from '../../app/App';
+import Loading from '../../common/loading/Loading';
 
 import SocialButton from '../../common/social-button/SocialButton';
 
@@ -15,7 +17,7 @@ const AuthRequirement = () => {
         <div className="auth-requirement">
             <div className="auth-requirement-wrapper col-sm-12 col-md-7 col-lg-5">
                 <h1 className="auth-requirement-title">
-                    Oops... You can't access this content.
+                    Oops... You can&apos;t access this content.
                 </h1>
                 <h3 className="auth-requirement-text">
                     Please, sign in and try again.
@@ -34,8 +36,11 @@ type ProtectedRouteProps = {
 };
 
 const ProtectedRoute = ({ children, ...args }: ProtectedRouteProps) => {
-    const user = useSession();
-    return <Route {...args}>{user ? children : <AuthRequirement />}</Route>;
+    const user = useCurrentUser();
+    if (user) {
+        return <Route {...args}>{user === 'unknown' ? <Loading /> : children}</Route>;
+    }
+    return <Route {...args}><AuthRequirement /></Route>;
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
- **Issue:** Resolves #116  
- **Description:** As requested on the issue, this PR adds a `ProtectedRoute` component that allows us to avoid the access of non-authenticated users to specific pages. This component has the same behavior as a regular `Route` component. Also, the pages of tracks, albums, and artists became protected, but this must be undone when all the issues related to non-authenticated users' access are resolved.