### PR TITLE
Create endpoint to get reviews from artist

### DIFF
--- a/server/src/artist/artistController.js
+++ b/server/src/artist/artistController.js
@@ -1,0 +1,55 @@
+/* @flow */
+
+import express from 'express';
+import { spotifySdk } from '../spotify/util';
+
+import { TRACK } from '../reviews/trackReviewController';
+import { ALBUM } from '../reviews/albumReviewController';
+import { getReviews } from '../reviews/reviewCollections';
+
+const router = express.Router();
+
+router.get('/artists/:id', async (req, res) => {
+    const averageRating = contentRatings =>
+        contentRatings.length > 0
+            ? contentRatings.reduce((x, y) => x + y) / contentRatings.length
+            : 0;
+
+    const artistId = req.params.id;
+
+    const artist = await spotifySdk.getArtist(artistId);
+    const topTracks = await spotifySdk.getArtistTopTracks(artistId, 'US');
+    const albums = (
+        await spotifySdk.getArtistAlbums(artistId, {
+            includeGroups: ['album'],
+        })
+    ).items;
+
+    const topTracksReviews = await Promise.all(
+        topTracks.map(async track => await getReviews(track.id, TRACK))
+    );
+    const topTracksRatings = topTracksReviews.map(reviews =>
+        reviews.map(review => review.rating)
+    );
+    const topTracksAverages = topTracksRatings.map(ratings =>
+        averageRating(ratings)
+    );
+
+    const albumsReviews = await Promise.all(
+        albums.map(async album => await getReviews(album.id, ALBUM))
+    );
+    const albumsRatings = albumsReviews.map(reviews =>
+        reviews.map(review => review.rating)
+    );
+    const albumsAverages = albumsRatings.map(ratings => averageRating(ratings));
+
+    res.status(200).send({
+        artist,
+        topTracks,
+        albums,
+        topTracksAverages,
+        albumsAverages,
+    });
+});
+
+export default router;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -11,6 +11,7 @@ import trackReviewsApi from './reviews/trackReviewController';
 import albumReviewsApi from './reviews/albumReviewController';
 import trackApi from './track/trackController';
 import albumApi from './album/albumController';
+import artistApi from './artist/artistController';
 import checkAuth from './firebase/firebaseAuthHandler';
 import { initSpotifyToken } from './spotify/util';
 
@@ -35,6 +36,7 @@ app.use(trackApi);
 app.use(albumApi);
 app.use(trackReviewsApi);
 app.use(albumReviewsApi);
+app.use(artistApi);
 
 const server = http.createServer(app);
 const { port } = config.host;


### PR DESCRIPTION
Added an endpoint to get artist information, alongside the top tracks and albums and their respective average ratings.
The route `/artists/:id` returns an object with the following format:
```js
{
    artist: { /* artist data */ },
    topTracks: [track1, track2],
    albums: [album1, album2],
    topTracksAverages: [4, 5],
    albumsAverages: [4, 4]
}
```
For a complete example, I created [this pastebin](https://pastebin.com/qpJEPPjy) (since it's almost 3000 lines long).

Closes #114 